### PR TITLE
Use environment Supabase configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
+const supabaseDomain = process.env.NEXT_PUBLIC_SUPABASE_URL
+  ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+  : undefined
+
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: process.cwd(),
@@ -9,7 +13,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    domains: ["ijeuusvwqcnljctkvjdi.supabase.co", "lh3.googleusercontent.com"],
+    domains: [supabaseDomain, "lh3.googleusercontent.com"].filter(Boolean),
   },
   // Ensure build outputs go to correct locations
   distDir: ".next",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -220,9 +220,8 @@ const validateDataIntegrity = (data, source, expectedCount, callback) => {
 }
 
 // Updated Supabase Configuration
-const SUPABASE_URL = "https://bdtmsfbhaztukqppnhdk.supabase.co"
-const SUPABASE_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJkdG1zZmJoYXp0dWtxcHBuaGRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyMDE0NTQsImV4cCI6MjA3MDc3NzQ1NH0.1nJz_lgeRQNTaiFohC5u6yk3OXEleA4sI5pgwPouRsU"
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 // P&L ONLY Account Classification - EXCLUDES Balance Sheet accounts
 const classifyAccount = (accountType, accountDetailType, accountName) => {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@supabase/supabase-js"
 
-const supabaseUrl = "https://bdtmsfbhaztukqppnhdk.supabase.co"
-const supabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJkdG1zZmJoYXp0dWtxcHBuaGRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyMDE0NTQsImV4cCI6MjA3MDc3NzQ1NH0.1nJz_lgeRQNTaiFohC5u6yk3OXEleA4sI5pgwPouRsU"
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- Create Supabase client from NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY
- Reference environment Supabase values in dashboard page
- Load Supabase domain dynamically in `next.config.ts` image configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 181 errors, 7 warnings)*
- `npm run type-check` *(fails: 23 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689eb4538e888333b12339c0cd1f7199