### PR TITLE
feat: switch class filters to customer filters

### DIFF
--- a/src/app/balance-sheet/page.tsx
+++ b/src/app/balance-sheet/page.tsx
@@ -29,7 +29,7 @@ interface TransactionDetail {
   date: string
   payeeCustomer: string | null
   memo: string | null
-  class: string | null
+  customer: string | null
   amount: number
   // Keep some additional fields for reference
   account: string
@@ -44,7 +44,7 @@ interface JournalEntryLine {
   date: string
   account: string
   memo: string | null
-  class: string | null
+  customer: string | null
   debit: string | number | null
   credit: string | number | null
 }
@@ -80,7 +80,7 @@ export default function BalanceSheetPage() {
   const [selectedMonth, setSelectedMonth] = useState<string>("December")
   const [selectedYear, setSelectedYear] = useState<string>("2023")
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Monthly")
-  const [selectedProperty, setSelectedProperty] = useState("All Properties")
+  const [selectedProperty, setSelectedProperty] = useState("All Customers")
   const [customStartDate, setCustomStartDate] = useState("")
   const [customEndDate, setCustomEndDate] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -91,7 +91,7 @@ export default function BalanceSheetPage() {
   const [equity, setEquity] = useState<BalanceSheetSection>({ title: "Equity", accounts: [], total: 0 })
 
   // Common state
-  const [availableProperties, setAvailableProperties] = useState<string[]>(["All Properties"])
+  const [availableProperties, setAvailableProperties] = useState<string[]>(["All Customers"])
   const [error, setError] = useState<string | null>(null)
   const [showTransactionModal, setShowTransactionModal] = useState(false)
   const [transactionDetails, setTransactionDetails] = useState<TransactionDetail[]>([])
@@ -319,7 +319,7 @@ export default function BalanceSheetPage() {
         .lte("balance_date", endDate)
         .order("balance_date", { ascending: false })
 
-      if (selectedProperty !== "All Properties") {
+      if (selectedProperty !== "All Customers") {
         manualBalanceQuery = manualBalanceQuery.eq("property_class", selectedProperty)
       }
 
@@ -445,16 +445,16 @@ export default function BalanceSheetPage() {
       const { data: propertyData, error: propertyError } = await supabase
         .from("journal_entry_lines")
         .select("class")
-        // .not("class", "is", null)
+        // .not("customer", "is", null)
 
       if (propertyError) throw propertyError
 
       const properties = new Set<string>()
       propertyData.forEach((row: any) => {
-        if (row.class) properties.add(row.class)
+        if (row.customer) properties.add(row.customer)
       })
 
-      setAvailableProperties(["All Properties", ...Array.from(properties).sort()])
+      setAvailableProperties(["All Customers", ...Array.from(properties).sort()])
     } catch (err) {
       console.error("Error fetching filters:", err)
     }
@@ -473,7 +473,7 @@ export default function BalanceSheetPage() {
       smartLog(`🔍 BALANCE SHEET DATA LOAD`)
       smartLog(`📅 As Of Date: ${endDate}`)
       smartLog(`📊 Period Activity From: ${periodStart}`)
-      smartLog(`🏢 Property Filter: "${selectedProperty}"`)
+      smartLog(`🏢 Customer Filter: "${selectedProperty}"`)
 
       // SINGLE QUERY: Get ALL balance sheet transactions up to as-of date
       let query = supabase
@@ -484,8 +484,8 @@ export default function BalanceSheetPage() {
         .lte("date", endDate)
         .order("date", { ascending: true })
 
-      if (selectedProperty !== "All Properties") {
-        query = query.eq("class", selectedProperty)
+      if (selectedProperty !== "All Customers") {
+        query = query.eq("customer", selectedProperty)
       }
 
       const { data: allTransactions, error } = await query
@@ -728,7 +728,7 @@ export default function BalanceSheetPage() {
             date: endDate,
             payeeCustomer: "System Calculated",
             memo: "Calculated Net Income from P&L accounts",
-            class: "All Properties",
+            customer: "All Customers",
             amount: netIncome,
             account: "Net Income",
             debit: netIncome > 0 ? 0 : Math.abs(netIncome),
@@ -823,7 +823,7 @@ export default function BalanceSheetPage() {
         date: tx.date,
         payeeCustomer,
         memo: tx.memo,
-        class: tx.class,
+        customer: tx.customer,
         amount,
         account: tx.account,
         debit: Number.parseFloat(tx.debit) || 0,
@@ -1346,9 +1346,9 @@ export default function BalanceSheetPage() {
                           <span className="font-medium">Memo:</span> {transaction.memo}
                         </div>
                       )}
-                      {transaction.class && (
+                      {transaction.customer && (
                         <div className="text-sm text-blue-600">
-                          <span className="font-medium">Class:</span> {transaction.class}
+                          <span className="font-medium">Customer:</span> {transaction.customer}
                         </div>
                       )}
                     </div>
@@ -1371,7 +1371,7 @@ export default function BalanceSheetPage() {
                         Memo
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Class
+                        Customer
                       </th>
                       <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Amount
@@ -1399,8 +1399,8 @@ export default function BalanceSheetPage() {
                           </div>
                         </td>
                         <td className="px-6 py-4 text-sm text-blue-600 max-w-xs">
-                          <div className="truncate" title={transaction.class || "N/A"}>
-                            {transaction.class || "N/A"}
+                          <div className="truncate" title={transaction.customer || "N/A"}>
+                            {transaction.customer || "N/A"}
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-medium">
@@ -1443,7 +1443,7 @@ export default function BalanceSheetPage() {
                       Memo
                     </th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Class
+                      Customer
                     </th>
                     <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Debit
@@ -1461,7 +1461,7 @@ export default function BalanceSheetPage() {
                       </td>
                       <td className="px-4 py-2 text-sm text-gray-900">{line.account}</td>
                       <td className="px-4 py-2 text-sm text-gray-500">{line.memo || ""}</td>
-                      <td className="px-4 py-2 text-sm text-gray-500">{line.class || ""}</td>
+                      <td className="px-4 py-2 text-sm text-gray-500">{line.customer || ""}</td>
                       <td className="px-4 py-2 whitespace-nowrap text-sm text-right text-red-600">
                         {formatCurrency(Number.parseFloat(line.debit?.toString() || "0"))}
                       </td>

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -50,7 +50,7 @@ interface JournalEntryLine {
   date: string
   account: string
   memo: string | null
-  class: string | null
+  customer: string | null
   debit: string | number | null
   credit: string | number | null
 }
@@ -133,7 +133,7 @@ export default function CashFlowPage() {
   const [selectedMonth, setSelectedMonth] = useState<string>("June")
   const [selectedYear, setSelectedYear] = useState<string>("2024")
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Monthly")
-  const [selectedProperty, setSelectedProperty] = useState("All Properties")
+  const [selectedProperty, setSelectedProperty] = useState("All Customers")
   const [selectedBankAccount, setSelectedBankAccount] = useState("All Bank Accounts")
   const [viewMode, setViewMode] = useState<ViewMode>("offset")
   const [periodType, setPeriodType] = useState<PeriodType>("monthly")
@@ -176,7 +176,7 @@ export default function CashFlowPage() {
   const [bankAccountData, setBankAccountData] = useState<BankAccountData[]>([])
 
   // Common state
-  const [availableProperties, setAvailableProperties] = useState<string[]>(["All Properties"])
+  const [availableProperties, setAvailableProperties] = useState<string[]>(["All Customers"])
   const [availableBankAccounts, setAvailableBankAccounts] = useState<string[]>(["All Bank Accounts"])
   const [error, setError] = useState<string | null>(null)
   const [showTransactionModal, setShowTransactionModal] = useState(false)
@@ -692,23 +692,23 @@ export default function CashFlowPage() {
     return "Trailing 12 Months"
   }
 
-  // ENHANCED: Fetch available properties and bank accounts using new fields
+  // ENHANCED: Fetch available customers and bank accounts using new fields
   const fetchFilters = async () => {
     try {
-      // Fetch properties from 'class' field
+      // Fetch customers from 'customer' field
       const { data: propertyData, error: propertyError } = await supabase
         .from("journal_entry_lines")
         .select("class")
-        // .not("class", "is", null)
+        // .not("customer", "is", null)
 
       if (propertyError) throw propertyError
 
       const properties = new Set<string>()
       propertyData.forEach((row: any) => {
-        if (row.class) properties.add(row.class)
+        if (row.customer) properties.add(row.customer)
       })
 
-      setAvailableProperties(["All Properties", ...Array.from(properties).sort()])
+      setAvailableProperties(["All Customers", ...Array.from(properties).sort()])
 
       // ENHANCED: Fetch bank accounts using entry_bank_account field
       const { data: bankData, error: bankError } = await supabase
@@ -746,7 +746,7 @@ export default function CashFlowPage() {
 
       console.log(`🔍 CASH FLOW BY BANK ACCOUNT - Using Enhanced Database`)
       console.log(`📅 Period: ${startDate} to ${endDate}`)
-      console.log(`🏢 Property Filter: "${selectedProperty}"`)
+      console.log(`🏢 Customer Filter: "${selectedProperty}"`)
       console.log(`🔄 Include Transfers: ${includeTransfers}`)
 
       // FIXED QUERY: Corrected transfer toggle logic
@@ -768,8 +768,8 @@ export default function CashFlowPage() {
         query = query.eq("is_cash_account", false).neq("report_category", "transfer")
       }
 
-      if (selectedProperty !== "All Properties") {
-        query = query.eq("class", selectedProperty)
+      if (selectedProperty !== "All Customers") {
+        query = query.eq("customer", selectedProperty)
       }
 
       const { data: cashFlowTransactions, error } = await query
@@ -894,7 +894,7 @@ export default function CashFlowPage() {
 
       console.log(`🔍 CASH FLOW OFFSET VIEW - Using Enhanced Database`)
       console.log(`📅 Period: ${startDate} to ${endDate}`)
-      console.log(`🏢 Property Filter: "${selectedProperty}"`)
+      console.log(`🏢 Customer Filter: "${selectedProperty}"`)
       console.log(`🏦 Bank Account Filter: "${selectedBankAccount}"`)
       console.log(`🔄 Include Transfers: ${includeTransfers}`)
 
@@ -917,8 +917,8 @@ export default function CashFlowPage() {
         query = query.eq("is_cash_account", false).neq("report_category", "transfer")
       }
 
-      if (selectedProperty !== "All Properties") {
-        query = query.eq("class", selectedProperty)
+      if (selectedProperty !== "All Customers") {
+        query = query.eq("customer", selectedProperty)
       }
 
       if (selectedBankAccount !== "All Bank Accounts") {
@@ -1067,7 +1067,7 @@ export default function CashFlowPage() {
 
       console.log(`🔍 CASH FLOW TRADITIONAL VIEW - Using Enhanced Database`)
       console.log(`📅 Period: ${startDate} to ${endDate}`)
-      console.log(`🏢 Property Filter: "${selectedProperty}"`)
+      console.log(`🏢 Customer Filter: "${selectedProperty}"`)
       console.log(`🏦 Bank Account Filter: "${selectedBankAccount}"`)
       console.log(`🔄 Include Transfers: ${includeTransfers}`)
 
@@ -1090,8 +1090,8 @@ export default function CashFlowPage() {
         query = query.eq("is_cash_account", false).neq("report_category", "transfer")
       }
 
-      if (selectedProperty !== "All Properties") {
-        query = query.eq("class", selectedProperty)
+      if (selectedProperty !== "All Customers") {
+        query = query.eq("customer", selectedProperty)
       }
 
       if (selectedBankAccount !== "All Bank Accounts") {
@@ -1108,7 +1108,7 @@ export default function CashFlowPage() {
       const propertyTransactions = new Map<string, any[]>()
 
       cashFlowTransactions.forEach((tx: any) => {
-        const property = tx.class || "Unclassified"
+        const property = tx.customer || "Unclassified"
         if (!propertyTransactions.has(property)) {
           propertyTransactions.set(property, [])
         }
@@ -1204,7 +1204,7 @@ export default function CashFlowPage() {
         customer: tx.customer,
         vendor: tx.vendor,
         name: tx.name,
-        class: tx.class,
+        customer: tx.customer,
         bankAccount: tx.entry_bank_account,
         accountType: tx.account_type,
         reportCategory: tx.report_category,
@@ -1245,7 +1245,7 @@ export default function CashFlowPage() {
         customer: tx.customer,
         vendor: tx.vendor,
         name: tx.name,
-        class: tx.class,
+        customer: tx.customer,
         bankAccount: tx.entry_bank_account,
         accountType: tx.account_type,
         reportCategory: tx.report_category,
@@ -1395,7 +1395,6 @@ export default function CashFlowPage() {
         customer: row.customer,
         vendor: row.vendor,
         name: row.name,
-        class: row.class,
       }))
 
       setTransactionDetails(transactionDetails)
@@ -1721,7 +1720,7 @@ export default function CashFlowPage() {
               </div>
             )}
 
-            {/* Property Filter */}
+            {/* Customer Filter */}
             <select
               value={selectedProperty}
               onChange={(e) => setSelectedProperty(e.target.value)}
@@ -1803,7 +1802,7 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedProperty !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}
                     </span>
@@ -1948,7 +1947,7 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedProperty !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}
                     </span>
@@ -2864,7 +2863,7 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedProperty !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}
                     </span>
@@ -3235,7 +3234,7 @@ export default function CashFlowPage() {
                         Amount
                       </th>
                       <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Class
+                        Customer
                       </th>
                     </tr>
                   </thead>
@@ -3269,9 +3268,9 @@ export default function CashFlowPage() {
                           {formatCurrency(transaction.impact)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-center">
-                          {transaction.class && (
+                          {transaction.customer && (
                             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                              {transaction.class}
+                              {transaction.customer}
                             </span>
                           )}
                         </td>
@@ -3310,7 +3309,7 @@ export default function CashFlowPage() {
                       Memo
                     </th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Class
+                      Customer
                     </th>
                     <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Debit
@@ -3328,7 +3327,7 @@ export default function CashFlowPage() {
                       </td>
                       <td className="px-4 py-2 text-sm text-gray-900">{line.account}</td>
                       <td className="px-4 py-2 text-sm text-gray-500">{line.memo || ""}</td>
-                      <td className="px-4 py-2 text-sm text-gray-500">{line.class || ""}</td>
+                      <td className="px-4 py-2 text-sm text-gray-500">{line.customer || ""}</td>
                       <td className="px-4 py-2 whitespace-nowrap text-sm text-right text-red-600">
                         {formatCurrency(Number.parseFloat(line.debit?.toString() || "0"))}
                       </td>

--- a/src/app/comparative-analysis/page.tsx
+++ b/src/app/comparative-analysis/page.tsx
@@ -36,14 +36,14 @@ type KPIs = {
 };
 
 export default function ComparativeAnalysisPage() {
-  const [mode, setMode] = useState<"period" | "class">("period");
+  const [mode, setMode] = useState<"period" | "customer">("period");
   const [startA, setStartA] = useState("");
   const [endA, setEndA] = useState("");
   const [startB, setStartB] = useState("");
   const [endB, setEndB] = useState("");
-  const [classA, setClassA] = useState("All Properties");
-  const [classB, setClassB] = useState("All Properties");
-  const [classes, setClasses] = useState<string[]>([]);
+  const [customerA, setCustomerA] = useState("All Customers");
+  const [customerB, setCustomerB] = useState("All Customers");
+  const [customers, setCustomers] = useState<string[]>([]);
   const [dataA, setDataA] = useState<KPIs | null>(null);
   const [dataB, setDataB] = useState<KPIs | null>(null);
   const [varianceRows, setVarianceRows] = useState<{
@@ -62,21 +62,21 @@ export default function ComparativeAnalysisPage() {
   const [modalTransactions, setModalTransactions] = useState<any[]>([]);
 
   useEffect(() => {
-    fetchClasses();
+    fetchCustomers();
   }, []);
 
-  const fetchClasses = async () => {
-    const { data } = await supabase.from("journal_entry_lines").select("class");
+  const fetchCustomers = async () => {
+    const { data } = await supabase.from("journal_entry_lines").select("customer");
     if (data) {
       const unique = Array.from(
         new Set(
           data
-            .map((d) => d.class)
+            .map((d) => d.customer)
             .filter((c) => c && c.trim())
             .map((c) => c.trim()),
         ),
       );
-      setClasses(["All Properties", ...unique]);
+      setCustomers(["All Customers", ...unique]);
     }
   };
 
@@ -87,8 +87,8 @@ export default function ComparativeAnalysisPage() {
       .gte("date", start)
       .lte("date", end);
 
-    if (property && property !== "All Properties") {
-      query = query.eq("class", property);
+    if (property && property !== "All Customers") {
+      query = query.eq("customer", property);
     }
 
     const { data, error } = await query;
@@ -220,17 +220,17 @@ export default function ComparativeAnalysisPage() {
 
   const fetchData = async () => {
     if (mode === "period" && (!startA || !endA || !startB || !endB)) return;
-    if (mode === "class" && (!startA || !endA)) return;
+    if (mode === "customer" && (!startA || !endA)) return;
 
     setLoading(true);
     setError(null);
     try {
       const [linesA, linesB] = await Promise.all([
-        fetchLines(startA, endA, mode === "class" ? classA : undefined),
+        fetchLines(startA, endA, mode === "customer" ? customerA : undefined),
         fetchLines(
           mode === "period" ? startB : startA,
           mode === "period" ? endB : endA,
-          mode === "class" ? classB : undefined,
+          mode === "customer" ? customerB : undefined,
         ),
       ]);
       const kpiA = computeKPIs(linesA);
@@ -365,7 +365,7 @@ export default function ComparativeAnalysisPage() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="period">Period vs Period</SelectItem>
-              <SelectItem value="class">Class vs Class</SelectItem>
+              <SelectItem value="customer">Customer vs Customer</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -412,16 +412,16 @@ export default function ComparativeAnalysisPage() {
           </>
         )}
 
-        {mode === "class" && (
+        {mode === "customer" && (
           <>
             <div className="flex flex-col">
-              <label className="text-sm text-gray-700 mb-1">Class A</label>
-              <Select value={classA} onValueChange={(v) => setClassA(v)}>
+          <label className="text-sm text-gray-700 mb-1">Customer A</label>
+              <Select value={customerA} onValueChange={(v) => setCustomerA(v)}>
                 <SelectTrigger className="w-48">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {classes.map((c) => (
+                  {customers.map((c) => (
                     <SelectItem key={c} value={c}>
                       {c}
                     </SelectItem>
@@ -430,13 +430,13 @@ export default function ComparativeAnalysisPage() {
               </Select>
             </div>
             <div className="flex flex-col">
-              <label className="text-sm text-gray-700 mb-1">Class B</label>
-              <Select value={classB} onValueChange={(v) => setClassB(v)}>
+          <label className="text-sm text-gray-700 mb-1">Customer B</label>
+              <Select value={customerB} onValueChange={(v) => setCustomerB(v)}>
                 <SelectTrigger className="w-48">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {classes.map((c) => (
+                  {customers.map((c) => (
                     <SelectItem key={c} value={c}>
                       {c}
                     </SelectItem>
@@ -803,7 +803,7 @@ export default function ComparativeAnalysisPage() {
                       Amount
                     </th>
                     <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">
-                      Class
+                      Customer
                     </th>
                     <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">
                       Set
@@ -825,7 +825,7 @@ export default function ComparativeAnalysisPage() {
                           {formatCurrency(Math.abs(amt))}
                         </td>
                         <td className="px-4 py-2 text-sm text-center">
-                          {t.class || ""}
+                          {t.customer || ""}
                         </td>
                         <td className="px-4 py-2 text-sm text-center">{t.set}</td>
                       </tr>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -323,7 +323,7 @@ const classifyAccount = (accountType, accountDetailType, accountName) => {
 
 // Hardcoded properties based on actual database data
 const HARDCODED_PROPERTIES = [
-  "All Properties",
+  "All Customers",
   "Cleveland",
   "Columbus IN",
   "Detroit",
@@ -349,11 +349,11 @@ const fetchProperties = async () => {
 
     if (response.ok) {
       const data = await response.json()
-      const classValues = data.map((item) => item.class).filter((cls) => cls && cls.trim() !== "")
+      const classValues = data.map((item) => item.customer).filter((cls) => cls && cls.trim() !== "")
 
       const uniqueClasses = [...new Set(classValues)].sort()
       const allProperties = [...new Set([...HARDCODED_PROPERTIES.slice(1), ...uniqueClasses])].sort()
-      const result = ["All Properties", ...allProperties]
+      const result = ["All Customers", ...allProperties]
 
       return result
     }
@@ -366,7 +366,7 @@ const fetchProperties = async () => {
 }
 
 // ENHANCED: Time series data fetching with Property Dimension support
-const fetchTimeSeriesData = async (property = "All Properties", monthYear, timePeriod, viewMode, onDataValidation) => {
+const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePeriod, viewMode, onDataValidation) => {
   try {
     const perfStart = performanceTracker.startTime("fetchTimeSeriesData")
     smartLog("🔍 FETCHING TIME SERIES DATA:", { property, monthYear, timePeriod, viewMode })
@@ -584,7 +584,7 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
 
       // FIXED: For by-property view, NEVER filter by property - we need ALL property data
       // Only filter by property for non-by-property views
-      if (viewMode !== "by-property" && property !== "All Properties") {
+      if (viewMode !== "by-property" && property !== "All Customers") {
         url += `&class=eq.${encodeURIComponent(property)}`
       }
 
@@ -613,7 +613,7 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
         if (viewMode === "by-property") {
           // Get available properties from the data
           const propertiesInData = [
-            ...new Set(rawData.map((row) => row.class).filter((cls) => cls && cls.trim() !== "")),
+            ...new Set(rawData.map((row) => row.customer).filter((cls) => cls && cls.trim() !== "")),
           ].sort()
           if (availableProperties.length === 0) {
             availableProperties = propertiesInData
@@ -628,7 +628,7 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
           // Group by account first, then by property within each account
           const groupedByAccount = rawData.reduce((acc, row) => {
             const accountName = row.account || "Unknown Account"
-            const propertyName = row.class || "No Property"
+            const propertyName = row.customer || "No Property"
 
             const category = classifyAccount(row.account_type, row.account_detail_type, accountName)
             if (category === null) {
@@ -670,7 +670,7 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
             accountsGrouped: Object.keys(groupedByAccount).length,
             sampleAccount: Object.keys(groupedByAccount)[0],
             sampleData: groupedByAccount[Object.keys(groupedByAccount)[0]],
-            availableProperties: propertiesInData,
+            availableCustomers: propertiesInData,
           })
 
           allData[range.label] = groupedByAccount
@@ -780,11 +780,11 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
         success: true,
         data: { "Trailing 12 Months": aggregatedData },
         periods: ["Trailing 12 Months"],
-        availableProperties: allAvailableProperties.sort(),
+        availableCustomers: allAvailableProperties.sort(),
         summary: {
           timePeriod,
           viewMode,
-          property: property === "All Properties" ? "ALL PROPERTIES" : property,
+          property: property === "All Customers" ? "ALL PROPERTIES" : property,
           dateRanges: [
             {
               start: dateRanges[0].start,
@@ -835,11 +835,11 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
         success: true,
         data: { "Trailing 12 Months": aggregatedData },
         periods: ["Trailing 12 Months"],
-        availableProperties: viewMode === "by-property" ? availableProperties : [],
+        availableCustomers: viewMode === "by-property" ? availableProperties : [],
         summary: {
           timePeriod,
           viewMode,
-          property: property === "All Properties" ? "ALL PROPERTIES" : property,
+          property: property === "All Customers" ? "ALL PROPERTIES" : property,
           dateRanges: [
             {
               start: dateRanges[0].start,
@@ -861,11 +861,11 @@ const fetchTimeSeriesData = async (property = "All Properties", monthYear, timeP
       success: true,
       data: allData,
       periods: dateRanges.map((r) => r.label),
-      availableProperties: viewMode === "by-property" ? availableProperties : [],
+      availableCustomers: viewMode === "by-property" ? availableProperties : [],
       summary: {
         timePeriod,
         viewMode,
-        property: property === "All Properties" ? "ALL PROPERTIES" : property,
+        property: property === "All Customers" ? "ALL PROPERTIES" : property,
         dateRanges: dateRanges,
         totalEntriesProcessed,
         periodsGenerated: dateRanges.length,
@@ -932,7 +932,7 @@ export default function MobileResponsiveFinancialsPage() {
   const [viewMode, setViewMode] = useState("by-property") // Default to by-property
   const [notification, setNotification] = useState({ show: false, message: "", type: "info" })
   const [timePeriodDropdownOpen, setTimePeriodDropdownOpen] = useState(false)
-  const [selectedProperties, setSelectedProperties] = useState(new Set(["All Properties"]))
+  const [selectedProperties, setSelectedProperties] = useState(new Set(["All Customers"]))
   const [propertyDropdownOpen, setPropertyDropdownOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false)
@@ -1037,9 +1037,9 @@ export default function MobileResponsiveFinancialsPage() {
               </select>
             </div>
 
-            {/* Properties multiselect */}
+            {/* Customers multiselect */}
             <div>
-              <div className="text-xs text-gray-600 mb-1">Properties</div>
+              <div className="text-xs text-gray-600 mb-1">Customers</div>
               <button
                 className="w-full rounded-md border px-3 py-2 text-sm text-left"
                 onClick={() => setPropertyDropdownOpen((v) => !v)}
@@ -1160,20 +1160,20 @@ export default function MobileResponsiveFinancialsPage() {
       setIsLoadingData(true)
       setDataError(null)
 
-      // FIXED: For by-property view, always use 'All Properties' to get all data
-      let propertyFilter = "All Properties"
-      if (viewMode !== "by-property" && selectedProperties.size > 0 && !selectedProperties.has("All Properties")) {
+      // FIXED: For by-property view, always use 'All Customers' to get all data
+      let propertyFilter = "All Customers"
+      if (viewMode !== "by-property" && selectedProperties.size > 0 && !selectedProperties.has("All Customers")) {
         propertyFilter = Array.from(selectedProperties)[0]
       }
 
       smartLog("🔍 LOADING DATA WITH FILTERS:", {
-        selectedProperties: Array.from(selectedProperties),
+        selectedCustomers: Array.from(selectedProperties),
         propertyFilter,
         month: selectedMonth,
         timePeriod,
         viewMode,
         note:
-          viewMode === "by-property" ? "FORCING All Properties for by-property view" : "Using selected property filter",
+          viewMode === "by-property" ? "FORCING All Customers for by-property view" : "Using selected property filter",
       })
 
       const timeSeriesResult = await fetchTimeSeriesData(
@@ -1195,7 +1195,7 @@ export default function MobileResponsiveFinancialsPage() {
       const propertyText =
         viewMode === "by-property"
           ? "all properties (by-property view)"
-          : selectedProperties.has("All Properties")
+          : selectedProperties.has("All Customers")
             ? "all property classes"
             : `${selectedProperties.size} selected property classes`
 
@@ -1212,11 +1212,11 @@ export default function MobileResponsiveFinancialsPage() {
   const handlePropertyToggle = (property) => {
     const newSelected = new Set(selectedProperties)
 
-    if (property === "All Properties") {
+    if (property === "All Customers") {
       newSelected.clear()
-      newSelected.add("All Properties")
+      newSelected.add("All Customers")
     } else {
-      newSelected.delete("All Properties")
+      newSelected.delete("All Customers")
 
       if (newSelected.has(property)) {
         newSelected.delete(property)
@@ -1225,7 +1225,7 @@ export default function MobileResponsiveFinancialsPage() {
       }
 
       if (newSelected.size === 0) {
-        newSelected.add("All Properties")
+        newSelected.add("All Customers")
       }
     }
 
@@ -1234,13 +1234,13 @@ export default function MobileResponsiveFinancialsPage() {
   }
 
   const getSelectedPropertiesText = () => {
-    if (selectedProperties.has("All Properties") || selectedProperties.size === 0) {
-      return "All Property Classes"
+    if (selectedProperties.has("All Customers") || selectedProperties.size === 0) {
+      return "All Customer"
     }
     if (selectedProperties.size === 1) {
       return Array.from(selectedProperties)[0]
     }
-    return `${selectedProperties.size} Property Classes Selected`
+    return `${selectedProperties.size} Customer Selected`
   }
 
   // Helper functions
@@ -1479,7 +1479,7 @@ export default function MobileResponsiveFinancialsPage() {
           periodKey: firstPeriodKey,
           accountCount: result.length,
           sampleAccount: result[0],
-          availableProperties: timeSeriesData.availableProperties,
+          availableCustomers: timeSeriesData.availableProperties,
         })
 
         return result
@@ -1595,7 +1595,7 @@ export default function MobileResponsiveFinancialsPage() {
       viewMode,
       periods: timeSeriesData.periods,
       dataKeys: Object.keys(timeSeriesData.data),
-      availableProperties: timeSeriesData.availableProperties,
+      availableCustomers: timeSeriesData.availableProperties,
     })
 
     // For by-property view with multiple properties, show property breakdown
@@ -1804,7 +1804,7 @@ export default function MobileResponsiveFinancialsPage() {
       currentData.forEach((account) => {
         if (account.entries) {
           account.entries.forEach((entry) => {
-            const property = entry.class || "No Property"
+            const property = entry.customer || "No Property"
             if (!propertyData[property]) {
               propertyData[property] = { revenue: 0, cogs: 0, opex: 0, otherIncome: 0, otherExpenses: 0 }
             }
@@ -2202,7 +2202,7 @@ export default function MobileResponsiveFinancialsPage() {
           <div className="flex justify-between items-center">
             <div>
               <h3 className="text-xl font-semibold text-gray-900">
-                Profit & Loss Statement {viewMode === "by-property" ? "(By Property Class)" : "(By Property Class)"}
+                Profit & Loss Statement {viewMode === "by-property" ? "(By Customer)" : "(By Customer)"}
               </h3>
               <div className="mt-2 text-sm text-gray-600">
                 Showing {timePeriod.toLowerCase()} {viewMode} view for {selectedMonth}
@@ -2412,7 +2412,7 @@ export default function MobileResponsiveFinancialsPage() {
                 <div className="text-xs text-gray-500">{kpis.netMargin.toFixed(1)}% margin</div>
               </div>
               <div className="text-center">
-                <div className="text-sm text-gray-600 mb-1">📊 Properties</div>
+                <div className="text-sm text-gray-600 mb-1">📊 Customers</div>
                 <div className="text-xl font-bold text-purple-600">
                   {timeSeriesData?.availableProperties?.length || 0}
                 </div>
@@ -2487,7 +2487,7 @@ export default function MobileResponsiveFinancialsPage() {
           {/* Property count */}
           <div className="mt-4 pt-4 border-t border-white border-opacity-20">
             <div className="flex justify-between items-center text-sm">
-              <span className="opacity-75">Properties:</span>
+              <span className="opacity-75">Customers:</span>
               <span className="font-semibold">{timeSeriesData?.availableProperties?.length || 0}</span>
             </div>
             <div className="flex justify-between items-center text-sm mt-1">
@@ -2976,7 +2976,7 @@ export default function MobileResponsiveFinancialsPage() {
 
                       <div className="flex justify-between text-sm text-gray-600">
                         <span>ID: {entry.id}</span>
-                        <span>Class: {entry.class || "No Class"}</span>
+                        <span>Customer: {entry.customer || "No Customer"}</span>
                       </div>
                     </div>
                   ))}
@@ -3079,7 +3079,7 @@ export default function MobileResponsiveFinancialsPage() {
                       {entry.memo && <div className="mb-2 text-xs text-gray-700">{entry.memo}</div>}
 
                       <div className="text-xs text-gray-600">
-                        <strong>Class:</strong> {entry.class || "No Class"}
+                        <strong>Customer:</strong> {entry.customer || "No Customer"}
                       </div>
                     </div>
                   ))}
@@ -3159,14 +3159,14 @@ export default function MobileResponsiveFinancialsPage() {
                 ))}
               </select>
 
-              {/* Property Classes Dropdown */}
+              {/* Customer Dropdown */}
               <div className="relative">
                 <button
                   onClick={() => setPropertyDropdownOpen(!propertyDropdownOpen)}
                   className="flex items-center justify-between w-56 px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm hover:border-blue-500 focus:outline-none focus:ring-2 transition-all"
                   style={{ "--tw-ring-color": BRAND_COLORS.secondary + "33" } as React.CSSProperties}
                 >
-                  <span className="truncate">All Property Classes</span>
+                  <span className="truncate">All Customer</span>
                   <ChevronDown
                     className={`w-4 h-4 ml-2 transition-transform ${propertyDropdownOpen ? "rotate-180" : ""}`}
                   />

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -221,7 +221,7 @@ export default function FinancialsPage() {
   const [monthDropdownOpen, setMonthDropdownOpen] = useState(false);
   const [yearDropdownOpen, setYearDropdownOpen] = useState(false);
   const [selectedProperties, setSelectedProperties] = useState<Set<string>>(
-    new Set(["All Properties"]),
+    new Set(["All Customers"]),
   );
   const [customStartDate, setCustomStartDate] = useState("");
   const [customEndDate, setCustomEndDate] = useState("");
@@ -232,7 +232,7 @@ export default function FinancialsPage() {
   const [plAccounts, setPlAccounts] = useState<PLAccount[]>([]);
   const [dataError, setDataError] = useState<string | null>(null);
   const [availableProperties, setAvailableProperties] = useState<string[]>([
-    "All Properties",
+    "All Customers",
   ]);
   const [showTransactionModal, setShowTransactionModal] = useState(false);
   const [transactionModalTitle, setTransactionModalTitle] = useState("");
@@ -493,7 +493,7 @@ export default function FinancialsPage() {
     try {
       const { startDate, endDate } = calculateDateRange();
       const selectedProperty =
-        Array.from(selectedProperties)[0] || "All Properties";
+        Array.from(selectedProperties)[0] || "All Customers";
 
       smartLog(`🔍 TIMEZONE-INDEPENDENT P&L DATA FETCH`);
       smartLog(`📅 Period: ${startDate} to ${endDate}`);
@@ -528,7 +528,7 @@ export default function FinancialsPage() {
         .order("date", { ascending: true });
 
       // Apply property filter
-      if (selectedProperty !== "All Properties") {
+      if (selectedProperty !== "All Customers") {
         query = query.eq("customer", selectedProperty);
       }
 
@@ -570,11 +570,11 @@ export default function FinancialsPage() {
       smartLog(`📈 Filtered to ${plTransactions.length} P&L transactions`);
       smartLog(`🔍 Sample P&L transactions:`, plTransactions.slice(0, 5));
 
-      // Get unique properties for filter dropdown using 'class' field
+      // Get unique customers for filter dropdown using 'customer' field
       const properties = new Set<string>();
       plTransactions.forEach((tx) => {
         if (tx.customer && tx.customer.trim()) {
-          properties.add(tx.class.trim());
+          properties.add(tx.customer.trim());
         }
       });
       setAvailableProperties([
@@ -1227,7 +1227,7 @@ export default function FinancialsPage() {
     if (viewMode === "Total") {
       return [];
     } else if (viewMode === "Customer") {
-      return availableProperties.filter((p) => p !== "All Properties");
+      return availableProperties.filter((p) => p !== "All Customers");
     } else if (viewMode === "Detail") {
       // For Detail view, show months in the date range using timezone-independent method
       const { startDate, endDate } = calculateDateRange();
@@ -1276,10 +1276,10 @@ export default function FinancialsPage() {
       ];
     }
 
-    if (viewMode === "Class") {
+    if (viewMode === "Customer") {
       // Filter transactions by property and calculate total
       const filteredTransactions = transactions.filter(
-        (tx) => tx.class === header,
+        (tx) => tx.customer === header,
       );
       const credits = filteredTransactions.reduce((sum, tx) => {
         const creditValue = tx.credit
@@ -1372,9 +1372,9 @@ export default function FinancialsPage() {
       });
     }
 
-    // Filter by property if specified (Class view)
-    if (property && viewMode === "Class") {
-      transactions = transactions.filter((tx) => tx.class === property);
+    // Filter by property if specified (Customer view)
+    if (property && viewMode === "Customer") {
+      transactions = transactions.filter((tx) => tx.customer === property);
     }
 
     let title = subAccount
@@ -1694,17 +1694,17 @@ export default function FinancialsPage() {
                         onChange={(e) => {
                           const newSelected = new Set(selectedProperties);
                           if (e.target.checked) {
-                            if (property === "All Properties") {
+                            if (property === "All Customers") {
                               newSelected.clear();
-                              newSelected.add("All Properties");
+                              newSelected.add("All Customers");
                             } else {
-                              newSelected.delete("All Properties");
+                              newSelected.delete("All Customers");
                               newSelected.add(property);
                             }
                           } else {
                             newSelected.delete(property);
                             if (newSelected.size === 0) {
-                              newSelected.add("All Properties");
+                              newSelected.add("All Customers");
                             }
                           }
                           setSelectedProperties(newSelected);
@@ -1758,10 +1758,10 @@ export default function FinancialsPage() {
   }`}
   style={{
     backgroundColor:
-      viewMode === "Customer" ? BRAND_COLORS.primary : undefined,  // ← Changed from "Class" to "Customer"
+      viewMode === "Customer" ? BRAND_COLORS.primary : undefined,  // ← Changed from "Customer" to "Customer"
   }}
 >
-  Customer  {/* ← Changed from "Class" to "Customer" */}
+  Customer  {/* ← Changed from "Customer" to "Customer" */}
 </button>
             </div>
 
@@ -1923,7 +1923,7 @@ export default function FinancialsPage() {
                   {plAccounts.length} accounts • Timezone-independent date
                   handling • Using account_type for P&L classification
                   {viewMode === "Detail" && " • Monthly breakdown"}
-                  {viewMode === "Class" && " • By property"}
+                  {viewMode === "Customer" && " • By property"}
                 </p>
               </div>
 
@@ -2035,7 +2035,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Class" ? header : undefined,
+                                      viewMode === "Customer" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2111,7 +2111,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Class"
+                                          viewMode === "Customer"
                                             ? header
                                             : undefined,
                                         )
@@ -2251,7 +2251,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Class" ? header : undefined,
+                                      viewMode === "Customer" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2327,7 +2327,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Class"
+                                          viewMode === "Customer"
                                             ? header
                                             : undefined,
                                         )
@@ -2583,7 +2583,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Class" ? header : undefined,
+                                      viewMode === "Customer" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2659,7 +2659,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Class"
+                                          viewMode === "Customer"
                                             ? header
                                             : undefined,
                                         )
@@ -2929,7 +2929,7 @@ export default function FinancialsPage() {
                         Amount
                       </th>
                       <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Class
+                        Customer
                       </th>
                     </tr>
                   </thead>
@@ -2978,9 +2978,9 @@ export default function FinancialsPage() {
                             {formatCurrency(Math.abs(netAmount))}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-center">
-                            {transaction.class && (
+                            {transaction.customer && (
                               <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                                {transaction.class}
+                                {transaction.customer}
                               </span>
                             )}
                           </td>
@@ -3020,7 +3020,7 @@ export default function FinancialsPage() {
                       Memo
                     </th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Class
+                      Customer
                     </th>
                     <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Debit
@@ -3038,7 +3038,7 @@ export default function FinancialsPage() {
                       </td>
                       <td className="px-4 py-2 text-sm text-gray-900">{line.account}</td>
                       <td className="px-4 py-2 text-sm text-gray-500">{line.memo || ""}</td>
-                      <td className="px-4 py-2 text-sm text-gray-500">{line.class || ""}</td>
+                      <td className="px-4 py-2 text-sm text-gray-500">{line.customer || ""}</td>
                       <td className="px-4 py-2 whitespace-nowrap text-sm text-right text-red-600">
                         {formatCurrency(Number.parseFloat(line.debit?.toString() || "0"))}
                       </td>

--- a/src/app/mobile-dashboard/page.tsx
+++ b/src/app/mobile-dashboard/page.tsx
@@ -278,7 +278,7 @@ export default function EnhancedMobileDashboard() {
       const { data } = await query;
       const map: Record<string, PropertySummary> = {};
       ((data as JournalRow[]) || []).forEach((row) => {
-        const cls = row.class || "General";
+        const cls = row.customer || "General";
         if (!map[cls]) {
           map[cls] = { 
             name: cls, 
@@ -489,7 +489,7 @@ export default function EnhancedMobileDashboard() {
       query =
         propertyName === "General"
           ? query.is("class", null)
-          : query.eq("class", propertyName);
+          : query.eq("customer", propertyName);
     }
     const { data } = await query;
     const rev: Record<string, number> = {};
@@ -525,7 +525,7 @@ export default function EnhancedMobileDashboard() {
       query =
         propertyName === "General"
           ? query.is("class", null)
-          : query.eq("class", propertyName);
+          : query.eq("customer", propertyName);
     }
     const { data } = await query;
     const op: Record<string, number> = {};
@@ -586,7 +586,7 @@ export default function EnhancedMobileDashboard() {
       query =
         selectedProperty === "General"
           ? query.is("class", null)
-          : query.eq("class", selectedProperty);
+          : query.eq("customer", selectedProperty);
     }
     const { data } = await query;
     const list: Transaction[] = ((data as JournalRow[]) || [])
@@ -609,7 +609,7 @@ export default function EnhancedMobileDashboard() {
           running: 0,
           payee: row.customer || row.vendor || row.name,
           memo: row.memo,
-          className: row.class,
+          className: row.customer,
           entryNumber: row.entry_number,
         };
       });
@@ -962,7 +962,7 @@ export default function EnhancedMobileDashboard() {
               <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '12px' }}>
                 <Award size={16} style={{ color: BRAND_COLORS.primary }} />
                 <span style={{ fontSize: '14px', fontWeight: '600', color: BRAND_COLORS.primary }}>
-                  Property Champions
+                  Customer Champions
                 </span>
               </div>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '8px' }}>
@@ -1168,7 +1168,7 @@ export default function EnhancedMobileDashboard() {
             </div>
           </div>
 
-          {/* Enhanced Property KPI Boxes */}
+          {/* Enhanced Customer KPI Boxes */}
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '16px' }}>
             {properties.map((p) => {
               const isRevenueKing = p.name === revenueKing;
@@ -2019,7 +2019,7 @@ export default function EnhancedMobileDashboard() {
                     <th style={{ textAlign: 'left', padding: '8px', fontSize: '12px', color: '#475569' }}>Date</th>
                     <th style={{ textAlign: 'left', padding: '8px', fontSize: '12px', color: '#475569' }}>Account</th>
                     <th style={{ textAlign: 'left', padding: '8px', fontSize: '12px', color: '#475569' }}>Memo</th>
-                    <th style={{ textAlign: 'left', padding: '8px', fontSize: '12px', color: '#475569' }}>Class</th>
+                    <th style={{ textAlign: 'left', padding: '8px', fontSize: '12px', color: '#475569' }}>Customer</th>
                     <th style={{ textAlign: 'right', padding: '8px', fontSize: '12px', color: '#475569' }}>Debit</th>
                     <th style={{ textAlign: 'right', padding: '8px', fontSize: '12px', color: '#475569' }}>Credit</th>
                   </tr>
@@ -2036,7 +2036,7 @@ export default function EnhancedMobileDashboard() {
                       </td>
                       <td style={{ padding: '8px', fontSize: '12px', color: '#0f172a' }}>{line.account}</td>
                       <td style={{ padding: '8px', fontSize: '12px', color: '#475569' }}>{line.memo || ''}</td>
-                      <td style={{ padding: '8px', fontSize: '12px', color: '#475569' }}>{line.class || ''}</td>
+                      <td style={{ padding: '8px', fontSize: '12px', color: '#475569' }}>{line.customer || ''}</td>
                       <td style={{ padding: '8px', textAlign: 'right', fontSize: '12px', color: BRAND_COLORS.danger }}>
                         {formatCurrency(Number(line.debit || 0))}
                       </td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -887,15 +887,15 @@ export default function FinancialOverviewPage() {
       });
     }
 
-    // Profitable properties
-    const profitableProperties = properties.filter((p) => p.netIncome > 0);
-    if (profitableProperties.length > 0) {
+    // Profitable customers
+    const profitableCustomers = properties.filter((p) => p.netIncome > 0);
+    if (profitableCustomers.length > 0) {
       alerts.push({
-        id: "profitable-properties",
+        id: "profitable-customers",
         type: "success",
-        title: "Strong Property Performance",
-        message: `${profitableProperties.length} of ${properties.length} properties are profitable`,
-        action: "View Properties",
+        title: "Strong Customer Performance",
+        message: `${profitableCustomers.length} of ${properties.length} customers are profitable`,
+        action: "View Customers",
         href: "/financials",
       });
     }
@@ -971,12 +971,12 @@ export default function FinancialOverviewPage() {
       const res = await fetch(
         `/api/organizations/${orgId}/dashboard-summary?start=${startDate}&end=${endDate}&includeProperties=true`,
       );
-      if (!res.ok) throw new Error("Failed to fetch property data");
+      if (!res.ok) throw new Error("Failed to fetch customer data");
       const json: { propertyBreakdown: PropertyPoint[] } = await res.json();
       setPropertyData(json.propertyBreakdown || []);
     } catch (e) {
       const err = e as Error;
-      setPropertyError(err.message || "Failed to load property data");
+      setPropertyError(err.message || "Failed to load customer data");
       setPropertyData([]);
     } finally {
       setLoadingProperty(false);
@@ -1086,12 +1086,12 @@ export default function FinancialOverviewPage() {
     margin: "margin",
     transactionCount: "transactions",
   } as const;
-  const propertySubtitle =
+  const customerSubtitle =
     timePeriod === "Monthly"
-      ? `Top 10 properties sorted by ${sortLabels[sortColumn]} for ${selectedMonth} ${selectedYear}`
-      : `Top 10 properties sorted by ${sortLabels[sortColumn]} for ${formatDate(propertyStart)} - ${formatDate(propertyEnd)}`;
+      ? `Top 10 customers sorted by ${sortLabels[sortColumn]} for ${selectedMonth} ${selectedYear}`
+      : `Top 10 customers sorted by ${sortLabels[sortColumn]} for ${formatDate(propertyStart)} - ${formatDate(propertyEnd)}`;
 
-  const sortedProperties = useMemo(() => {
+  const sortedCustomers = useMemo(() => {
     if (!financialData?.propertyBreakdown) return [];
     return [...financialData.propertyBreakdown]
       .map((p) => ({
@@ -1108,8 +1108,8 @@ export default function FinancialOverviewPage() {
       .slice(0, 10);
   }, [financialData, sortColumn, sortDirection]);
 
-  const topPropertyTotals = useMemo(() => {
-    const totals = sortedProperties.reduce(
+  const topCustomerTotals = useMemo(() => {
+    const totals = sortedCustomers.reduce(
       (acc, p) => {
         acc.revenue += p.revenue || 0;
         acc.expenses += p.expenses || 0;
@@ -1122,7 +1122,7 @@ export default function FinancialOverviewPage() {
       ...totals,
       margin: totals.revenue ? (totals.netIncome / totals.revenue) * 100 : 0,
     };
-  }, [sortedProperties]);
+  }, [sortedCustomers]);
 
   const handleSort = (column: SortColumn) => {
     if (sortColumn === column) {
@@ -1723,13 +1723,13 @@ export default function FinancialOverviewPage() {
                 </CardContent>
               </Card>
 
-              {/* Property Performance Pie Chart */}
+              {/* Customer Performance Pie Chart */}
               <Card>
                 <CardHeader className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <PieChart className="h-4 w-4 text-gray-600" />
                     <CardTitle className="text-lg font-semibold">
-                      Property Performance
+                      Customer Performance
                     </CardTitle>
                   </div>
                   <div className="flex flex-wrap gap-2">
@@ -1756,12 +1756,12 @@ export default function FinancialOverviewPage() {
                   )}
                   {loadingProperty && (
                     <div className="text-sm text-gray-500">
-                      Loading properties...
+                      Loading customers...
                     </div>
                   )}
                   {!loadingProperty && propertyChartData.length === 0 && (
                     <div className="flex flex-col items-center justify-center py-8 text-gray-500">
-                      <p>No property data available</p>
+                      <p>No customer data available</p>
                       <Button
                         className="mt-4 flex items-center gap-2"
                         onClick={handleSync}
@@ -1923,14 +1923,14 @@ export default function FinancialOverviewPage() {
               </div>
             </div>
 
-            {/* Top Properties Performance */}
+            {/* Top Customers Performance */}
             <div className="bg-white rounded-lg shadow-sm overflow-hidden">
               <div className="p-6 border-b border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-900">
-                  Top Performing Properties
+                  Top Performing Customers
                 </h3>
                 <div className="text-sm text-gray-600 mt-1">
-                  {propertySubtitle}
+                  {customerSubtitle}
                 </div>
               </div>
               <div className="overflow-x-auto">
@@ -1938,7 +1938,7 @@ export default function FinancialOverviewPage() {
                   <thead className="bg-gray-50">
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Property
+                        Customer
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         <button
@@ -2033,93 +2033,93 @@ export default function FinancialOverviewPage() {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                    {sortedProperties.map((property, index) => {
-                      const margin = property.margin;
+                    {sortedCustomers.map((customer, index) => {
+                      const margin = customer.margin;
                       return (
-                        <tr key={property.name} className="hover:bg-gray-50">
-                            <td className="px-6 py-4 whitespace-nowrap">
-                              <div className="flex items-center">
-                                <div
-                                  className={`w-3 h-3 rounded-full mr-3 ${
-                                    index === 0
-                                      ? "bg-yellow-400"
-                                      : index === 1
-                                        ? "bg-gray-400"
-                                        : index === 2
-                                          ? "bg-yellow-600"
-                                          : "bg-gray-300"
-                                  }`}
-                                ></div>
-                                <div className="text-sm font-medium text-gray-900">
-                                  {property.name}
-                                </div>
+                        <tr key={customer.name} className="hover:bg-gray-50">
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <div className="flex items-center">
+                              <div
+                                className={`w-3 h-3 rounded-full mr-3 ${
+                                  index === 0
+                                    ? "bg-yellow-400"
+                                    : index === 1
+                                      ? "bg-gray-400"
+                                      : index === 2
+                                        ? "bg-yellow-600"
+                                        : "bg-gray-300"
+                                }`}
+                              ></div>
+                              <div className="text-sm font-medium text-gray-900">
+                                {customer.name}
                               </div>
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                              {formatCurrency(property.revenue)}
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                              {formatCurrency(property.expenses)}
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap">
-                              <span
-                                className={`text-sm font-medium ${
-                                  property.netIncome >= 0
-                                    ? "text-green-600"
+                            </div>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                            {formatCurrency(customer.revenue)}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                            {formatCurrency(customer.expenses)}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <span
+                              className={`text-sm font-medium ${
+                                customer.netIncome >= 0
+                                  ? "text-green-600"
+                                  : "text-red-600"
+                              }`}
+                            >
+                              {formatCurrency(customer.netIncome)}
+                            </span>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <span
+                              className={`text-sm ${
+                                margin >= 20
+                                  ? "text-green-600"
+                                  : margin >= 10
+                                    ? "text-yellow-600"
                                     : "text-red-600"
-                                }`}
-                              >
-                                {formatCurrency(property.netIncome)}
-                              </span>
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap">
-                              <span
-                                className={`text-sm ${
-                                  margin >= 20
-                                    ? "text-green-600"
-                                    : margin >= 10
-                                      ? "text-yellow-600"
-                                      : "text-red-600"
-                                }`}
-                              >
-                                {margin.toFixed(1)}%
-                              </span>
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                              {property.transactionCount}
-                            </td>
-                          </tr>
-                        );
-                      })}
+                              }`}
+                            >
+                              {margin.toFixed(1)}%
+                            </span>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            {customer.transactionCount}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
             </div>
 
-            {/* Top Properties Summary */}
+            {/* Top Customers Summary */}
             <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-6 border border-blue-200">
               <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div className="text-center">
                   <div className="text-2xl font-bold text-blue-600">
-                    {formatCurrency(topPropertyTotals.revenue)}
+                    {formatCurrency(topCustomerTotals.revenue)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Revenue</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-purple-600">
-                    {formatCurrency(topPropertyTotals.expenses)}
+                    {formatCurrency(topCustomerTotals.expenses)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Expenses</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-green-600">
-                    {formatCurrency(topPropertyTotals.netIncome)}
+                    {formatCurrency(topCustomerTotals.netIncome)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Net Income</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-orange-600">
-                    {topPropertyTotals.margin.toFixed(1)}%
+                    {topCustomerTotals.margin.toFixed(1)}%
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Margin</div>
                 </div>


### PR DESCRIPTION
## Summary
- replace class-based queries and filters with customer equivalents across dashboards and reports
- update UI labels and defaults from "Properties" to "Customers"
- adjust transaction filtering and table headers to use customer field

## Testing
- `pnpm lint` *(fails: Do not pass children as props, unexpected any, etc.)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ecef8ade88333bd2e7a98c1749248