### PR TITLE
feat: hide customer names on dashboard charts

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2647,14 +2647,7 @@ export default function MobileResponsiveFinancialsPage() {
               ) : (
                 <BarChart data={generateCustomerChartData()}>
                   <CartesianGrid strokeDasharray="2 2" stroke="#f1f5f9" />
-                  <XAxis
-                    dataKey="name"
-                    tick={{ fontSize: 10 }}
-                    angle={-45}
-                    textAnchor="end"
-                    height={60}
-                    interval={0}
-                  />
+                  <XAxis dataKey="name" hide />
                   <YAxis tickFormatter={(value) => `${(value / 1000).toFixed(0)}k`} tick={{ fontSize: 10 }} />
                   <Tooltip
                     formatter={(value) => [formatCurrency(value), propertyChartMetric === "income" ? "Revenue" : "Net Income"]}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1070,16 +1070,6 @@ export default function FinancialOverviewPage() {
       .sort((a, b) => b.value - a.value);
   }, [propertyData, propertyChartMetric]);
 
-  const customerLegendPayload = useMemo(
-    () =>
-      propertyChartData.slice(0, 15).map((entry, index) => ({
-        value: entry.name,
-        type: "square",
-        color: CHART_COLORS[index % CHART_COLORS.length],
-      })),
-    [propertyChartData],
-  );
-
   const totalPropertyValue = useMemo(
     () => propertyChartData.reduce((sum, p) => sum + p.value, 0),
     [propertyChartData],
@@ -1843,17 +1833,15 @@ export default function FinancialOverviewPage() {
                             ))}
                           </Pie>
                           <Tooltip content={<PropertyTooltip />} />
-                          <Legend payload={customerLegendPayload} />
                         </RechartsPieChart>
                       ) : (
                         <BarChart data={propertyChartData}>
                           <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="name" />
+                          <XAxis dataKey="name" hide />
                           <YAxis />
                           <Tooltip
                             formatter={(value) => formatCurrency(value as number)}
                           />
-                          <Legend payload={customerLegendPayload} />
                           <Bar dataKey="value">
                             {propertyChartData.map((entry, index) => (
                               <Cell


### PR DESCRIPTION
## Summary
- hide customer names on customer performance charts, keep names in hover tooltips

## Testing
- `pnpm lint` *(fails: multiple lint errors across repository)*
- `pnpm type-check` *(fails: TypeScript errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689f102764708333ab97f60861999ea7