### PR TITLE
Filter cash flow transaction drilldown to cash accounts

### DIFF
--- a/src/app/mobile-dashboard/page.tsx
+++ b/src/app/mobile-dashboard/page.tsx
@@ -654,6 +654,13 @@ export default function EnhancedMobileDashboard() {
       .eq("account", account)
       .gte("date", start)
       .lte("date", end);
+
+    if (reportType === "cf") {
+      query = query
+        .not("entry_bank_account", "is", null)
+        .eq("is_cash_account", false)
+        .neq("report_category", "transfer");
+    }
     if (selectedProperty) {
       query =
         selectedProperty === "General"


### PR DESCRIPTION
## Summary
- ensure mobile cash flow drilldown only includes transactions tied to bank sources

## Testing
- `pnpm lint` *(fails: Do not pass children as props and many Unexpected any, unused vars errors)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never' and similar errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f944a97e48333af5050c7c34f6133