### PR TITLE
feat: show net income percentage

### DIFF
--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -2787,34 +2787,98 @@ export default function FinancialsPage() {
                                 )
                               );
                             }, 0);
-                          const headerNet =
-                            headerIncome - headerCogs - headerExpenses;
-                          return (
-                            <td
-                              key={header}
-                              className={`px-6 py-4 whitespace-nowrap text-sm text-right font-bold ${
-                                headerNet >= 0
-                                  ? "text-green-700"
-                                  : "text-red-700"
-                              }`}
-                            >
-                              {formatCurrency(headerNet)}
-                            </td>
-                          );
-                        })}
+                      const headerNet =
+                        headerIncome - headerCogs - headerExpenses;
+                      return (
                         <td
-                          className={`px-6 py-4 whitespace-nowrap text-sm text-right font-bold text-xl ${
-                            netIncome >= 0 ? "text-green-700" : "text-red-700"
+                          key={header}
+                          className={`px-6 py-4 whitespace-nowrap text-sm text-right font-bold ${
+                            headerNet >= 0
+                              ? "text-green-700"
+                              : "text-red-700"
                           }`}
                         >
-                          {formatCurrency(netIncome)}
+                          {formatCurrency(headerNet)}
                         </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              )}
+                      );
+                    })}
+                    <td
+                      className={`px-6 py-4 whitespace-nowrap text-sm text-right font-bold text-xl ${
+                        netIncome >= 0 ? "text-green-700" : "text-red-700"
+                      }`}
+                    >
+                      {formatCurrency(netIncome)}
+                    </td>
+                  </tr>
+
+                  {/* Net Income Percentage */}
+                  <tr>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      Net Income %
+                    </td>
+                    {columnHeaders.map((header) => {
+                      const headerIncome = groupedAccounts.income.reduce(
+                        (sum, group) => {
+                          return (
+                            sum +
+                            getCellValue(
+                              group.account,
+                              header,
+                              true,
+                              group.subAccounts,
+                            )
+                          );
+                        },
+                        0,
+                      );
+                      const headerCogs = groupedAccounts.cogs.reduce(
+                        (sum, group) => {
+                          return (
+                            sum +
+                            getCellValue(
+                              group.account,
+                              header,
+                              true,
+                              group.subAccounts,
+                            )
+                          );
+                        },
+                        0,
+                      );
+                      const headerExpenses = groupedAccounts.expenses.reduce(
+                        (sum, group) => {
+                          return (
+                            sum +
+                            getCellValue(
+                              group.account,
+                              header,
+                              true,
+                              group.subAccounts,
+                            )
+                          );
+                        }, 0);
+                      const headerNet =
+                        headerIncome - headerCogs - headerExpenses;
+                      const pct =
+                        headerIncome !== 0 ? headerNet / headerIncome : 0;
+                      return (
+                        <td
+                          key={header}
+                          className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right"
+                        >
+                          {formatPercentage(pct)}
+                        </td>
+                      );
+                    })}
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
+                      {formatPercentage(netIncomePercent)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
+          )}
+        </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- display Net Income % row under Net Income in the P&L statement

## Testing
- `pnpm lint` (fails: React Hook useEffect has a missing dependency, Unexpected any, etc.)
- `pnpm type-check` (fails: Property 'growth' does not exist on type 'never', etc.)

------
https://chatgpt.com/codex/tasks/task_e_689febe05f9883339795506367f2956f