### PR TITLE
Fix OpenAI integration and add dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "next-themes": "latest",
     "papaparse": "^5.4.1",
     "path": "latest",
+    "openai": "^4.0.0",
     "react": "^19",
     "react-chartjs-2": "^5.3.0",
     "react-day-picker": "latest",

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,21 +1,24 @@
 import OpenAI from 'openai'
 
-if (!process.env.OPENAI_API_KEY) {
-  throw new Error('Missing OPENAI_API_KEY environment variable')
-}
-
+// Create the client with the API key if available. The key is validated
+// at runtime when requests are made so that builds don't fail when the
+// environment variable is missing.
 export const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 })
 
 export const createCFOCompletion = async (message, context) => {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('Missing OPENAI_API_KEY environment variable')
+  }
+
   try {
     const completion = await openai.chat.completions.create({
-      model: "gpt-4",
+      model: 'gpt-4o-mini',
       messages: [
         {
           role: "system",
-          content: `You are an AI CFO assistant for I AM CFO platform. 
+          content: `You are an AI CFO assistant for I AM CFO platform.
           You analyze financial data from journal entries and A/R aging reports.
           Provide concise, actionable insights for mobile users.
           Focus on property management financial analysis.


### PR DESCRIPTION
## Summary
- instantiate OpenAI client without crashing builds when `OPENAI_API_KEY` is missing
- switch to `gpt-4o-mini` and validate API key at runtime
- add `openai` dependency

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/openai: Forbidden - 403)*
- `pnpm lint` *(fails: react/no-children-pro, @typescript-eslint/no-explicit-any, ...)*
- `pnpm build` *(fails: Failed to fetch font `Inter`: https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap)*

------
https://chatgpt.com/codex/tasks/task_e_68a09a0e802483339d32a9f51b683467