### PR TITLE
Fix mobile microphone API endpoint and meta tag

### DIFF
--- a/src/app/ClientRootLayout.tsx
+++ b/src/app/ClientRootLayout.tsx
@@ -91,6 +91,7 @@ export default function ClientRootLayout({
           <link rel="icon" type="image/png" href="/favicon.png" />
           <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+          <meta name="mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-title" content="I AM CFO" />
           <meta name="theme-color" content="#56B6E9" />
@@ -110,6 +111,7 @@ export default function ClientRootLayout({
           <link rel="icon" type="image/png" href="/favicon.png" />
           <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+          <meta name="mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-title" content="I AM CFO" />
           <meta name="theme-color" content="#56B6E9" />
@@ -126,6 +128,7 @@ export default function ClientRootLayout({
           <link rel="icon" type="image/png" href="/favicon.png" />
           <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+          <meta name="mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-title" content="I AM CFO" />
           <meta name="theme-color" content="#56B6E9" />
@@ -141,6 +144,7 @@ export default function ClientRootLayout({
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="I AM CFO" />
         <meta name="theme-color" content="#56B6E9" />

--- a/src/app/api/ai-chat/route.js
+++ b/src/app/api/ai-chat/route.js
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { createCFOCompletion } from '../../../lib/openai'
+
+export async function POST(request) {
+  try {
+    const { message, context } = await request.json()
+
+    if (!message?.trim()) {
+      return NextResponse.json(
+        { error: 'Message is required' },
+        { status: 400 }
+      )
+    }
+
+    const aiResponse = await createCFOCompletion(message, context)
+    return NextResponse.json({ response: aiResponse })
+  } catch (error) {
+    console.error('AI Chat Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to process AI request' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/mobile-dashboard/page.tsx
+++ b/src/app/mobile-dashboard/page.tsx
@@ -250,6 +250,7 @@ export default function EnhancedMobileDashboard() {
         
         if (finalTranscript) {
           processAIQuery(finalTranscript);
+          recognitionInstance.stop();
         }
       };
       


### PR DESCRIPTION
## Summary
- add `/api/ai-chat` endpoint to handle voice queries
- include `mobile-web-app-capable` meta tag to avoid deprecation warnings
- stop speech recognition once a final transcript is processed

## Testing
- `pnpm lint` *(fails: Do not pass children as props; Unexpected any; etc.)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never'; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c088740c83339dce9accc34aba8a