### PR TITLE
fix: improve AI chat error handling

### DIFF
--- a/src/app/api/ai-chat-mobile/route.js
+++ b/src/app/api/ai-chat-mobile/route.js
@@ -38,9 +38,8 @@ export async function POST(request) {
 
   } catch (error) {
     console.error('❌ AI Chat Error:', error)
-    
     return NextResponse.json(
-      { error: 'Failed to process AI request' },
+      { error: error.message || 'Failed to process AI request' },
       { status: 500 }
     )
   }

--- a/src/app/api/ai-chat/route.js
+++ b/src/app/api/ai-chat/route.js
@@ -17,7 +17,7 @@ export async function POST(request) {
   } catch (error) {
     console.error('AI Chat Error:', error)
     return NextResponse.json(
-      { error: 'Failed to process AI request' },
+      { error: error.message || 'Failed to process AI request' },
       { status: 500 }
     )
   }

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,15 +1,16 @@
 // Simple helper around the OpenAI Chat Completions API using fetch.
 
 export const createCFOCompletion = async (message, context) => {
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error('Missing OPENAI_API_KEY environment variable')
+  const apiKey = process.env.OPENAI_API_KEY || process.env.NEXT_PUBLIC_OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error('Missing OpenAI API key')
   }
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
         model: 'gpt-4',


### PR DESCRIPTION
## Summary
- support using either `OPENAI_API_KEY` or `NEXT_PUBLIC_OPENAI_API_KEY`
- surface underlying error messages from AI chat routes

## Testing
- `pnpm run lint` *(fails: react/no-children-prop, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, etc.)*
- `pnpm run type-check` *(fails: Property 'growth' does not exist on type 'never', Type '{}' is missing the following properties from type '{ active: any; payload: any; label: any; }', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf07b90c83339358f4cfd07e338f