### PR TITLE
feat: add customer filters and AR/AP drilldowns

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -142,7 +142,8 @@ export default function CashFlowPage() {
   const [selectedMonth, setSelectedMonth] = useState<string>("June")
   const [selectedYear, setSelectedYear] = useState<string>("2024")
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Monthly")
-  const [selectedProperty, setSelectedProperty] = useState("All Properties")
+  // Filter by customer instead of class/property
+  const [selectedCustomer, setSelectedCustomer] = useState("All Customers")
   const [selectedBankAccount, setSelectedBankAccount] = useState("All Bank Accounts")
   const [viewMode, setViewMode] = useState<ViewMode>("offset")
   const [periodType, setPeriodType] = useState<PeriodType>("monthly")
@@ -185,12 +186,14 @@ export default function CashFlowPage() {
   const [bankAccountData, setBankAccountData] = useState<BankAccountData[]>([])
 
   // Common state
-  const [availableProperties, setAvailableProperties] = useState<string[]>(["All Properties"])
+  const [availableCustomers, setAvailableCustomers] = useState<string[]>(["All Customers"])
   const [availableBankAccounts, setAvailableBankAccounts] = useState<string[]>(["All Bank Accounts"])
   const [error, setError] = useState<string | null>(null)
   const [showTransactionModal, setShowTransactionModal] = useState(false)
   const [transactionDetails, setTransactionDetails] = useState<TransactionDetail[]>([])
   const [modalTitle, setModalTitle] = useState("")
+  const [groupedTransactions, setGroupedTransactions] = useState<Record<string, TransactionDetail[]>>({})
+  const [expandedCustomers, setExpandedCustomers] = useState<Record<string, boolean>>({})
   const [offsetTransactions, setOffsetTransactions] = useState<any[]>([])
   const [bankTransactions, setBankTransactions] = useState<any[]>([])
   const [journalEntryLines, setJournalEntryLines] = useState<JournalEntryLine[]>([])
@@ -765,23 +768,23 @@ export default function CashFlowPage() {
     return "Trailing 12 Months"
   }
 
-  // ENHANCED: Fetch available properties and bank accounts using new fields
+  // ENHANCED: Fetch available customers and bank accounts using new fields
   const fetchFilters = async () => {
     try {
-      // Fetch properties from 'class' field
-      const { data: propertyData, error: propertyError } = await supabase
+      // Fetch customers from 'customer' field
+      const { data: customerData, error: customerError } = await supabase
         .from("journal_entry_lines")
-        .select("class")
-        .not("class", "is", null)
+        .select("customer")
+        .not("customer", "is", null)
 
-      if (propertyError) throw propertyError
+      if (customerError) throw customerError
 
-      const properties = new Set<string>()
-      propertyData.forEach((row: any) => {
-        if (row.class) properties.add(row.class)
+      const customers = new Set<string>()
+      customerData.forEach((row: any) => {
+        if (row.customer) customers.add(row.customer)
       })
 
-      setAvailableProperties(["All Properties", ...Array.from(properties).sort()])
+      setAvailableCustomers(["All Customers", ...Array.from(customers).sort()])
 
       // ENHANCED: Fetch bank accounts using entry_bank_account field
       const { data: bankData, error: bankError } = await supabase
@@ -821,14 +824,14 @@ export default function CashFlowPage() {
 
       let query = supabase
         .from("journal_entry_lines")
-        .select("entry_number,date,entry_bank_account,debit,credit,report_category,class")
+        .select("entry_number,date,entry_bank_account,debit,credit,report_category,customer")
         .gte("date", startDate)
         .lt("date", toExclusiveDate(endDate))
         .eq("is_cash_account", true)
         .not("entry_bank_account", "is", null)
 
-      if (selectedProperty !== "All Properties") {
-        query = query.eq("class", selectedProperty)
+      if (selectedCustomer !== "All Customers") {
+        query = query.eq("customer", selectedCustomer)
       }
       if (selectedBankAccount !== "All Bank Accounts") {
         query = query.eq("entry_bank_account", selectedBankAccount)
@@ -897,12 +900,12 @@ export default function CashFlowPage() {
     // Attempt to use the cash_related_offsets view
     let viewQuery = supabase
       .from("cash_related_offsets")
-      .select("entry_number,date,class,account,account_type,report_category,debit,credit,cash_effect,cash_bank_account")
+      .select("entry_number,date,class,customer,account,account_type,report_category,debit,credit,cash_effect,cash_bank_account")
       .gte("date", startDate)
       .lt("date", toExclusiveDate(endDate))
 
-    if (selectedProperty !== "All Properties") {
-      viewQuery = viewQuery.eq("class", selectedProperty)
+    if (selectedCustomer !== "All Customers") {
+      viewQuery = viewQuery.eq("customer", selectedCustomer)
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       viewQuery = viewQuery.eq("cash_bank_account", selectedBankAccount)
@@ -919,13 +922,13 @@ export default function CashFlowPage() {
     // Option B fallback: first fetch cash lines
     let cashQuery = supabase
       .from("journal_entry_lines")
-      .select("entry_number,entry_bank_account")
+      .select("entry_number,entry_bank_account,customer")
       .gte("date", startDate)
       .lt("date", toExclusiveDate(endDate))
       .eq("is_cash_account", true)
 
-    if (selectedProperty !== "All Properties") {
-      cashQuery = cashQuery.eq("class", selectedProperty)
+    if (selectedCustomer !== "All Customers") {
+      cashQuery = cashQuery.eq("customer", selectedCustomer)
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       cashQuery = cashQuery.eq("entry_bank_account", selectedBankAccount)
@@ -951,7 +954,7 @@ export default function CashFlowPage() {
 
     let offsetQuery = supabase
       .from("journal_entry_lines")
-      .select("entry_number,date,class,account,account_type,report_category,debit,credit")
+      .select("entry_number,date,class,customer,account,account_type,report_category,debit,credit")
       .in("entry_number", entryNumbers)
       .eq("is_cash_account", false)
       .gte("date", startDate)
@@ -1113,13 +1116,13 @@ export default function CashFlowPage() {
   const checkDataQuality = async (offsets: any[], startDate: string, endDate: string) => {
     let cashQuery = supabase
       .from("journal_entry_lines")
-      .select("entry_number,debit,credit,entry_bank_account,report_category,class,date")
+      .select("entry_number,debit,credit,entry_bank_account,report_category,customer,class,date")
       .gte("date", startDate)
       .lt("date", toExclusiveDate(endDate))
       .eq("is_cash_account", true)
 
-    if (selectedProperty !== "All Properties") {
-      cashQuery = cashQuery.eq("class", selectedProperty)
+    if (selectedCustomer !== "All Customers") {
+      cashQuery = cashQuery.eq("customer", selectedCustomer)
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       cashQuery = cashQuery.eq("entry_bank_account", selectedBankAccount)
@@ -1389,8 +1392,31 @@ export default function CashFlowPage() {
         name: row.name,
         class: row.class,
       }))
-
       setTransactionDetails(transactionDetails)
+
+      const hasReceivableOrPayable = transactionDetails.some((t) => {
+        const type = t.accountType?.toLowerCase() || ""
+        return (
+          type.includes("accounts receivable") ||
+          type.includes("a/r") ||
+          type.includes("accounts payable") ||
+          type.includes("a/p")
+        )
+      })
+
+      if (hasReceivableOrPayable) {
+        const groups: Record<string, TransactionDetail[]> = {}
+        transactionDetails.forEach((t) => {
+          const key = t.customer || t.vendor || t.name || "Unknown"
+          if (!groups[key]) groups[key] = []
+          groups[key].push(t)
+        })
+        setGroupedTransactions(groups)
+        setExpandedCustomers({})
+      } else {
+        setGroupedTransactions({})
+      }
+
       setShowTransactionModal(true)
     } catch (err) {
       console.error("Error fetching cash flow transaction details:", err)
@@ -1490,7 +1516,7 @@ export default function CashFlowPage() {
     selectedYear,
     customStartDate,
     customEndDate,
-    selectedProperty,
+    selectedCustomer,
     selectedBankAccount,
     viewMode,
     periodType,
@@ -1713,16 +1739,16 @@ export default function CashFlowPage() {
               </div>
             )}
 
-            {/* Property Filter */}
+            {/* Customer Filter */}
             <select
-              value={selectedProperty}
-              onChange={(e) => setSelectedProperty(e.target.value)}
+              value={selectedCustomer}
+              onChange={(e) => setSelectedCustomer(e.target.value)}
               className="px-4 py-2 border border-gray-300 rounded-lg bg-white text-sm hover:border-blue-500 focus:outline-none focus:ring-2 transition-all"
               style={{ "--tw-ring-color": BRAND_COLORS.secondary + "33" } as React.CSSProperties}
             >
-              {availableProperties.map((property) => (
-                <option key={property} value={property}>
-                  {property}
+              {availableCustomers.map((customer) => (
+                <option key={customer} value={customer}>
+                  {customer}
                 </option>
               ))}
             </select>
@@ -1828,9 +1854,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedCustomer !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Property: {selectedProperty}
+                      Customer: {selectedCustomer}
                     </span>
                   )}
                 </div>
@@ -1973,9 +1999,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedCustomer !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Property: {selectedProperty}
+                      Customer: {selectedCustomer}
                     </span>
                   )}
                   {selectedBankAccount !== "All Bank Accounts" && (
@@ -2889,9 +2915,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedProperty !== "All Properties" && (
+                  {selectedCustomer !== "All Customers" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Property: {selectedProperty}
+                      Customer: {selectedCustomer}
                     </span>
                   )}
                   {selectedBankAccount !== "All Bank Accounts" && (
@@ -3265,43 +3291,117 @@ export default function CashFlowPage() {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                  {transactionDetails.map((transaction, index) => (
-                      <tr
-                        key={`${transaction.entryNumber}-${index}`}
-                        className="hover:bg-gray-50 cursor-pointer"
-                        onClick={() => openJournalEntry(transaction.entryNumber)}
-                      >
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {formatDate(transaction.date)}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {transaction.name ||
-                            transaction.vendor ||
-                            transaction.customer ||
-                            "N/A"}
-                        </td>
-                        <td
-                          className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate"
-                          title={transaction.memo || ""}
-                        >
-                          {transaction.memo || "-"}
-                        </td>
-                        <td
-                          className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${
-                            transaction.impact >= 0 ? "text-green-600" : "text-red-600"
-                          }`}
-                        >
-                          {formatCurrency(transaction.impact)}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-center">
-                          {transaction.class && (
-                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                              {transaction.class}
-                            </span>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
+                    {Object.keys(groupedTransactions).length > 0
+                      ? Object.entries(groupedTransactions).map(([customer, txs]) => {
+                          const total = txs.reduce((sum, t) => sum + t.impact, 0)
+                          const isExpanded = expandedCustomers[customer]
+                          return (
+                            <React.Fragment key={customer}>
+                              <tr
+                                onClick={() =>
+                                  setExpandedCustomers((prev) => ({
+                                    ...prev,
+                                    [customer]: !prev[customer],
+                                  }))
+                                }
+                                className="bg-gray-50 cursor-pointer"
+                              >
+                                <td
+                                  colSpan={5}
+                                  className="px-6 py-4 text-sm font-medium text-gray-900"
+                                >
+                                  {isExpanded ? (
+                                    <ChevronDown className="inline w-4 h-4 mr-2" />
+                                  ) : (
+                                    <ChevronRight className="inline w-4 h-4 mr-2" />
+                                  )}
+                                  {customer} - {formatCurrency(total)}
+                                </td>
+                              </tr>
+                              {isExpanded &&
+                                txs.map((transaction, index) => (
+                                  <tr
+                                    key={`${transaction.entryNumber}-${index}`}
+                                    className="hover:bg-gray-50 cursor-pointer"
+                                    onClick={() =>
+                                      openJournalEntry(transaction.entryNumber)
+                                    }
+                                  >
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                      {formatDate(transaction.date)}
+                                    </td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                      {transaction.name ||
+                                        transaction.vendor ||
+                                        transaction.customer ||
+                                        "N/A"}
+                                    </td>
+                                    <td
+                                      className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate"
+                                      title={transaction.memo || ""}
+                                    >
+                                      {transaction.memo || "-"}
+                                    </td>
+                                    <td
+                                      className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${
+                                        transaction.impact >= 0
+                                          ? "text-green-600"
+                                          : "text-red-600"
+                                      }`}
+                                    >
+                                      {formatCurrency(transaction.impact)}
+                                    </td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-center">
+                                      {transaction.class && (
+                                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                          {transaction.class}
+                                        </span>
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                            </React.Fragment>
+                          )
+                        })
+                      : transactionDetails.map((transaction, index) => (
+                          <tr
+                            key={`${transaction.entryNumber}-${index}`}
+                            className="hover:bg-gray-50 cursor-pointer"
+                            onClick={() => openJournalEntry(transaction.entryNumber)}
+                          >
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              {formatDate(transaction.date)}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                              {transaction.name ||
+                                transaction.vendor ||
+                                transaction.customer ||
+                                "N/A"}
+                            </td>
+                            <td
+                              className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate"
+                              title={transaction.memo || ""}
+                            >
+                              {transaction.memo || "-"}
+                            </td>
+                            <td
+                              className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${
+                                transaction.impact >= 0
+                                  ? "text-green-600"
+                                  : "text-red-600"
+                              }`}
+                            >
+                              {formatCurrency(transaction.impact)}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-center">
+                              {transaction.class && (
+                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                  {transaction.class}
+                                </span>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
                   </tbody>
                 </table>
               </div>

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -1396,11 +1396,16 @@ export default function CashFlowPage() {
 
       const hasReceivableOrPayable = transactionDetails.some((t) => {
         const type = t.accountType?.toLowerCase() || ""
+        const acct = t.account?.toLowerCase() || ""
         return (
           type.includes("accounts receivable") ||
+          acct.includes("accounts receivable") ||
           type.includes("a/r") ||
+          acct.includes("a/r") ||
           type.includes("accounts payable") ||
-          type.includes("a/p")
+          acct.includes("accounts payable") ||
+          type.includes("a/p") ||
+          acct.includes("a/p")
         )
       })
 


### PR DESCRIPTION
## Summary
- allow cash flow filtering by customer instead of class
- enable accounts receivable/payable drilldowns grouped by customer

## Testing
- `npm run lint` *(fails: Do not pass children as props, Unexpected any, and more)*
- `npm run type-check` *(fails: Property 'growth' does not exist on type 'never', and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e2657c883338a24daa43dcec392