### PR TITLE
fix: avoid double counting sub accounts in P&L

### DIFF
--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -1163,8 +1163,12 @@ export default function FinancialsPage() {
             : sum + (debitValue - creditValue);
         }, 0);
 
+        // Calculate the parent's own amount excluding sub-account totals
+        const subAmount = group.subs.reduce((sum, sub) => sum + sub.amount, 0);
+        const parentOnlyAmount = group.parent.amount - subAmount;
+
         result.push({
-          account: group.parent,
+          account: { ...group.parent, amount: parentOnlyAmount },
           subAccounts: group.subs.sort((a, b) =>
             a.account.localeCompare(b.account),
           ),


### PR DESCRIPTION
## Summary
- ensure parent accounts exclude sub-account totals when expanded

## Testing
- `pnpm lint` *(fails: numerous existing lint errors across repository)*
- `pnpm type-check` *(fails: existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c4e68a08333b019262498d1e898