### PR TITLE
feat: add searchable multi-customer filter

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -7,6 +7,7 @@ import * as XLSX from "xlsx"
 import jsPDF from "jspdf"
 import autoTable from "jspdf-autotable"
 import { supabase } from "@/lib/supabaseClient"
+import CustomerMultiSelect from "@/components/CustomerMultiSelect"
 
 // I AM CFO Brand Colors
 const BRAND_COLORS = {
@@ -166,7 +167,7 @@ export default function CashFlowPage() {
   const [selectedYear, setSelectedYear] = useState<string>("2024")
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Monthly")
   // Filter by customer instead of class/property
-  const [selectedCustomer, setSelectedCustomer] = useState("All Customers")
+  const [selectedCustomers, setSelectedCustomers] = useState<Set<string>>(new Set(["All Customers"]))
   const [selectedBankAccount, setSelectedBankAccount] = useState("All Bank Accounts")
   const [viewMode, setViewMode] = useState<ViewMode>("offset")
   const [periodType, setPeriodType] = useState<PeriodType>("monthly")
@@ -838,8 +839,8 @@ export default function CashFlowPage() {
         .eq("is_cash_account", true)
         .not("entry_bank_account", "is", null)
 
-      if (selectedCustomer !== "All Customers") {
-        query = query.eq("customer", selectedCustomer)
+      if (!selectedCustomers.has("All Customers")) {
+        query = query.in("customer", Array.from(selectedCustomers))
       }
       if (selectedBankAccount !== "All Bank Accounts") {
         query = query.eq("entry_bank_account", selectedBankAccount)
@@ -912,8 +913,8 @@ export default function CashFlowPage() {
       .gte("date", startDate)
       .lt("date", toExclusiveDate(endDate))
 
-    if (selectedCustomer !== "All Customers") {
-      viewQuery = viewQuery.eq("customer", selectedCustomer)
+    if (!selectedCustomers.has("All Customers")) {
+      viewQuery = viewQuery.in("customer", Array.from(selectedCustomers))
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       viewQuery = viewQuery.eq("cash_bank_account", selectedBankAccount)
@@ -935,8 +936,8 @@ export default function CashFlowPage() {
       .lt("date", toExclusiveDate(endDate))
       .eq("is_cash_account", true)
 
-    if (selectedCustomer !== "All Customers") {
-      cashQuery = cashQuery.eq("customer", selectedCustomer)
+    if (!selectedCustomers.has("All Customers")) {
+      cashQuery = cashQuery.in("customer", Array.from(selectedCustomers))
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       cashQuery = cashQuery.eq("entry_bank_account", selectedBankAccount)
@@ -1140,8 +1141,8 @@ export default function CashFlowPage() {
       .lt("date", toExclusiveDate(endDate))
       .eq("is_cash_account", true)
 
-    if (selectedCustomer !== "All Customers") {
-      cashQuery = cashQuery.eq("customer", selectedCustomer)
+    if (!selectedCustomers.has("All Customers")) {
+      cashQuery = cashQuery.in("customer", Array.from(selectedCustomers))
     }
     if (selectedBankAccount !== "All Bank Accounts") {
       cashQuery = cashQuery.eq("entry_bank_account", selectedBankAccount)
@@ -1523,7 +1524,7 @@ export default function CashFlowPage() {
     selectedYear,
     customStartDate,
     customEndDate,
-    selectedCustomer,
+    selectedCustomers,
     selectedBankAccount,
     viewMode,
     periodType,
@@ -1747,18 +1748,13 @@ export default function CashFlowPage() {
             )}
 
             {/* Customer Filter */}
-            <select
-              value={selectedCustomer}
-              onChange={(e) => setSelectedCustomer(e.target.value)}
-              className="px-4 py-2 border border-gray-300 rounded-lg bg-white text-sm hover:border-blue-500 focus:outline-none focus:ring-2 transition-all"
-              style={{ "--tw-ring-color": BRAND_COLORS.secondary + "33" } as React.CSSProperties}
-            >
-              {availableCustomers.map((customer) => (
-                <option key={customer} value={customer}>
-                  {customer}
-                </option>
-              ))}
-            </select>
+            <CustomerMultiSelect
+              options={availableCustomers}
+              selected={selectedCustomers}
+              onChange={setSelectedCustomers}
+              accentColor={BRAND_COLORS.secondary}
+              label="Customer"
+            />
 
             {/* Bank Account Filter */}
             {(viewMode === "offset" ||
@@ -1861,9 +1857,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedCustomer !== "All Customers" && (
+                  {!selectedCustomers.has("All Customers") && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Customer: {selectedCustomer}
+                      Customer: {Array.from(selectedCustomers).join(", ")}
                     </span>
                   )}
                 </div>
@@ -2006,9 +2002,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedCustomer !== "All Customers" && (
+                  {!selectedCustomers.has("All Customers") && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Customer: {selectedCustomer}
+                      Customer: {Array.from(selectedCustomers).join(", ")}
                     </span>
                   )}
                   {selectedBankAccount !== "All Bank Accounts" && (
@@ -2938,9 +2934,9 @@ export default function CashFlowPage() {
                           : timePeriod === "Trailing 12"
                             ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
                             : `For ${timePeriod} Period`}
-                  {selectedCustomer !== "All Customers" && (
+                  {!selectedCustomers.has("All Customers") && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
-                      Customer: {selectedCustomer}
+                      Customer: {Array.from(selectedCustomers).join(", ")}
                     </span>
                   )}
                   {selectedBankAccount !== "All Bank Accounts" && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { supabase } from "@/lib/supabaseClient";
+import CustomerMultiSelect from "@/components/CustomerMultiSelect";
 
 // I AM CFO Brand Colors
 const BRAND_COLORS = {
@@ -150,11 +151,9 @@ export default function FinancialOverviewPage() {
   const [timePeriodDropdownOpen, setTimePeriodDropdownOpen] = useState(false);
   const [monthDropdownOpen, setMonthDropdownOpen] = useState(false);
   const [yearDropdownOpen, setYearDropdownOpen] = useState(false);
-  const [customerDropdownOpen, setCustomerDropdownOpen] = useState(false);
   const timePeriodDropdownRef = useRef<HTMLDivElement>(null);
   const monthDropdownRef = useRef<HTMLDivElement>(null);
   const yearDropdownRef = useRef<HTMLDivElement>(null);
-  const customerDropdownRef = useRef<HTMLDivElement>(null);
   const [financialData, setFinancialData] = useState(null);
   const [error, setError] = useState(null);
   const [lastUpdated, setLastUpdated] = useState(null);
@@ -353,12 +352,6 @@ export default function FinancialOverviewPage() {
   // Click outside handler for dropdowns
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        customerDropdownRef.current &&
-        !customerDropdownRef.current.contains(event.target as Node)
-      ) {
-        setCustomerDropdownOpen(false);
-      }
       if (
         timePeriodDropdownRef.current &&
         !timePeriodDropdownRef.current.contains(event.target as Node)
@@ -1584,57 +1577,13 @@ export default function FinancialOverviewPage() {
                     </CardTitle>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="relative" ref={customerDropdownRef}>
-                      <button
-                        onClick={() => setCustomerDropdownOpen(!customerDropdownOpen)}
-                        className="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
-                        style={
-                          {
-                            "--tw-ring-color": BRAND_COLORS.primary + "33",
-                          } as React.CSSProperties
-                        }
-                      >
-                        Customer: {Array.from(selectedCustomers).join(", ")}
-                        <ChevronDown className="w-4 h-4 ml-1" />
-                      </button>
-
-                      {customerDropdownOpen && (
-                        <div className="absolute right-0 z-10 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                          {availableCustomers.map((cust) => (
-                            <label
-                              key={cust}
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={selectedCustomers.has(cust)}
-                                onChange={(e) => {
-                                  const newSelected = new Set(selectedCustomers);
-                                  if (e.target.checked) {
-                                    if (cust === "All Customers") {
-                                      newSelected.clear();
-                                      newSelected.add("All Customers");
-                                    } else {
-                                      newSelected.delete("All Customers");
-                                      newSelected.add(cust);
-                                    }
-                                  } else {
-                                    newSelected.delete(cust);
-                                    if (newSelected.size === 0) {
-                                      newSelected.add("All Customers");
-                                    }
-                                  }
-                                  setSelectedCustomers(newSelected);
-                                }}
-                                className="mr-3 rounded"
-                                style={{ accentColor: BRAND_COLORS.primary }}
-                              />
-                              {cust}
-                            </label>
-                          ))}
-                        </div>
-                      )}
-                    </div>
+                    <CustomerMultiSelect
+                      options={availableCustomers}
+                      selected={selectedCustomers}
+                      onChange={setSelectedCustomers}
+                      accentColor={BRAND_COLORS.primary}
+                      label="Customer"
+                    />
                     <Button
                       className={`h-8 w-8 p-0 ${chartType === "line" ? "" : "bg-white text-gray-700 border border-gray-200"}`}
                       onClick={() => setChartType("line")}

--- a/src/components/CustomerMultiSelect.tsx
+++ b/src/components/CustomerMultiSelect.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { ChevronDown } from "lucide-react";
+
+interface Props {
+  label?: string;
+  options: string[];
+  selected: Set<string>;
+  onChange: (selected: Set<string>) => void;
+  allLabel?: string;
+  accentColor?: string;
+}
+
+export default function CustomerMultiSelect({
+  label = "Customers",
+  options,
+  selected,
+  onChange,
+  allLabel = "All Customers",
+  accentColor = "#56B6E9",
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const filtered = options.filter((opt) =>
+    opt.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const toggleOption = (opt: string) => {
+    const next = new Set(selected);
+    if (next.has(opt)) {
+      next.delete(opt);
+    } else {
+      next.add(opt);
+    }
+    if (opt === allLabel) {
+      next.clear();
+      next.add(allLabel);
+    } else {
+      next.delete(allLabel);
+      if (next.size === 0) next.add(allLabel);
+    }
+    onChange(next);
+  };
+
+  const selectAll = () => {
+    const visible = filtered.filter((o) => o !== allLabel);
+    if (visible.length === 0) return;
+    const next = new Set(selected);
+    visible.forEach((o) => next.add(o));
+    next.delete(allLabel);
+    onChange(next);
+  };
+
+  const clearAll = () => {
+    const next = new Set<string>();
+    next.add(allLabel);
+    onChange(next);
+  };
+
+  const displayLabel = () => {
+    if (selected.has(allLabel) || selected.size === 0) return allLabel;
+    const arr = Array.from(selected);
+    return arr.length > 1 ? `${arr[0]} +${arr.length - 1}` : arr[0];
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+        style={{ "--tw-ring-color": accentColor + "33" } as React.CSSProperties}
+      >
+        {label}: {displayLabel()}
+        <ChevronDown className="w-4 h-4 ml-2" />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+          <div className="p-2 border-b border-gray-200">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search..."
+              className="w-full px-2 py-1 border border-gray-300 rounded"
+            />
+            <div className="flex justify-between mt-2">
+              <button
+                type="button"
+                className="text-xs text-blue-600 hover:underline"
+                onClick={selectAll}
+              >
+                Select All
+              </button>
+              <button
+                type="button"
+                className="text-xs text-blue-600 hover:underline"
+                onClick={clearAll}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+          {filtered.map((opt) => (
+            <label
+              key={opt}
+              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(opt)}
+                onChange={() => toggleOption(opt)}
+                className="mr-3 rounded"
+                style={{ accentColor }}
+              />
+              {opt}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable customer multi-select with search, select all and clear
- enable multi-customer filtering on P&L, cash flow and overview pages

## Testing
- `pnpm lint` *(fails: Do not pass children as props, Unexpected any, and others)*
- `pnpm type-check` *(fails: Property 'growth' does not exist, Type '{}' missing props, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc5edcd883339b1edd8e93cbad49