### PR TITLE
Add payroll navigation tab with Supabase payments data

### DIFF
--- a/src/app/ClientRootLayout.tsx
+++ b/src/app/ClientRootLayout.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import { Inter } from "next/font/google"
 import "./globals.css"
 import { useState, useEffect } from "react"
-import { BarChart3, DollarSign, TrendingUp, CreditCard, FileText, Users, Menu, X, BarChart2, Settings } from "lucide-react"
+import { BarChart3, DollarSign, TrendingUp, CreditCard, FileText, Users, Menu, X, BarChart2, Settings, Wallet } from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import Image from "next/image"
@@ -56,6 +56,7 @@ const navigation = [
   { name: "Cash Flow", href: "/cash-flow", icon: DollarSign },
   { name: "A/R", href: "/accounts-receivable", icon: CreditCard },
   { name: "A/P", href: "/accounts-payable", icon: Users },
+  { name: "Payroll", href: "/payroll", icon: Wallet },
   {
     name: "Comparative Analysis",
     href: "/comparative-analysis",


### PR DESCRIPTION
## Summary
- add Payroll tab to sidebar navigation
- fetch and display payment records from Supabase payments table on Payroll page

## Testing
- `pnpm run type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm run lint` *(fails: React/TS lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ff3a3a78833394c55da5ab205e77