### PR TITLE
Enable payroll payment queries from mobile AI tool

### DIFF
--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -77,13 +77,33 @@ export const createCFOCompletion = async (message, context) => {
           type: "function",
           function: {
             name: "getPaymentsSummary",
-            description: "Get payroll payments summarized by department with optional department filter",
+            description: "Get payroll payments with optional filters for date range, employee, department, and amount",
             parameters: {
               type: "object",
               properties: {
+                startDate: {
+                  type: "string",
+                  description: "Start date in YYYY-MM-DD format"
+                },
+                endDate: {
+                  type: "string",
+                  description: "End date in YYYY-MM-DD format"
+                },
+                employee: {
+                  type: "string",
+                  description: "Employee name to filter"
+                },
                 department: {
                   type: "string",
-                  description: "Optional department name to filter"
+                  description: "Department name to filter"
+                },
+                minAmount: {
+                  type: "number",
+                  description: "Minimum payment amount"
+                },
+                maxAmount: {
+                  type: "number",
+                  description: "Maximum payment amount"
                 }
               },
               required: []
@@ -189,14 +209,16 @@ export const createCFOCompletion = async (message, context) => {
           type: "function",
           function: {
             name: "getPaymentsSummary",
-            description: "Get payroll payments summarized by department with optional department filter",
+            description: "Get payroll payments with optional filters for date range, employee, department, and amount",
             parameters: {
               type: "object",
               properties: {
-                department: {
-                  type: "string",
-                  description: "Optional department name to filter"
-                }
+                startDate: { type: "string", description: "Start date in YYYY-MM-DD format" },
+                endDate: { type: "string", description: "End date in YYYY-MM-DD format" },
+                employee: { type: "string", description: "Employee name to filter" },
+                department: { type: "string", description: "Department name to filter" },
+                minAmount: { type: "number", description: "Minimum payment amount" },
+                maxAmount: { type: "number", description: "Maximum payment amount" }
               },
               required: []
             }


### PR DESCRIPTION
## Summary
- extend `getPaymentsSummary` server function to filter payments by date range, employee, department and amount
- expose `getPaymentsSummary` to the mobile AI assistant tools

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b2230c758083338e485a129d9fa3c5