### PR TITLE
fix payroll function call

### DIFF
--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -72,45 +72,7 @@ export const createCFOCompletion = async (message, context) => {
         role: "user",
         content: message
       }
-        ,
-        {
-          type: "function",
-          function: {
-            name: "getPaymentsSummary",
-            description: "Get payroll payments with optional filters for date range, employee, department, and amount",
-            parameters: {
-              type: "object",
-              properties: {
-                startDate: {
-                  type: "string",
-                  description: "Start date in YYYY-MM-DD format"
-                },
-                endDate: {
-                  type: "string",
-                  description: "End date in YYYY-MM-DD format"
-                },
-                employee: {
-                  type: "string",
-                  description: "Employee name to filter"
-                },
-                department: {
-                  type: "string",
-                  description: "Department name to filter"
-                },
-                minAmount: {
-                  type: "number",
-                  description: "Minimum payment amount"
-                },
-                maxAmount: {
-                  type: "number",
-                  description: "Maximum payment amount"
-                }
-              },
-              required: []
-            }
-          }
-        }
-        ]
+    ]
 
     let completionOptions = {
       model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- remove stray function descriptor from OpenAI message list
- ensure payroll queries use function-calling tools for `getPaymentsSummary`

## Testing
- `pnpm lint` (fails: Do not pass children as props. Instead, nest children between the opening and closing tags.)
- `pnpm type-check` (fails: Property 'growth' does not exist on type 'never'.)


------
https://chatgpt.com/codex/tasks/task_e_68b225d0b6a0833380635bab4a641a66