### PR TITLE
fix: load OpenAI key at runtime

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -3,11 +3,10 @@
 
 import { availableFunctions } from '../server/functions';
 
-if (!process.env.OPENAI_API_KEY) {
-  throw new Error('Missing OPENAI_API_KEY environment variable');
-}
-
-async function createChatCompletion(body: any) {
+async function createChatCompletion(body: Record<string, unknown>) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('Missing OPENAI_API_KEY environment variable');
+  }
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- move OpenAI key validation inside `createChatCompletion`
- convert OpenAI helper to TypeScript for compilation

## Testing
- `pnpm run lint` *(fails: many pre-existing lint errors)*
- `pnpm run build` *(fails: network access for Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b25c767ce08333b991957af49d74bf