### PR TITLE
Default financial pages to current month and year

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -163,8 +163,12 @@ const yearsList = Array.from({ length: 10 }, (_, i) => (new Date().getFullYear()
 
 export default function CashFlowPage() {
   // All state variables
-  const [selectedMonth, setSelectedMonth] = useState<string>("June")
-  const [selectedYear, setSelectedYear] = useState<string>("2024")
+  const [selectedMonth, setSelectedMonth] = useState<string>(
+    () => new Date().toLocaleString("en-US", { month: "long" }),
+  )
+  const [selectedYear, setSelectedYear] = useState<string>(
+    () => new Date().getFullYear().toString(),
+  )
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("Monthly")
   // Filter by customer instead of class/property
   const [selectedCustomers, setSelectedCustomers] = useState<Set<string>>(new Set(["All Customers"]))
@@ -700,8 +704,9 @@ export default function CashFlowPage() {
     let endDate: string
 
     if (timePeriod === "Custom") {
-      startDate = customStartDate || "2024-01-01"
-      endDate = customEndDate || "2024-12-31"
+      const year = new Date().getFullYear()
+      startDate = customStartDate || `${year}-01-01`
+      endDate = customEndDate || `${year}-12-31`
     } else if (timePeriod === "YTD") {
       const monthIndex = monthsList.indexOf(selectedMonth)
       const year = Number.parseInt(selectedYear)

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -208,8 +208,12 @@ const formatDateDisplay = (dateString: string) => {
 };
 
 export default function FinancialsPage() {
-  const [selectedMonth, setSelectedMonth] = useState<string>("June");
-  const [selectedYear, setSelectedYear] = useState<string>("2025");
+  const [selectedMonth, setSelectedMonth] = useState<string>(
+    () => new Date().toLocaleString("en-US", { month: "long" }),
+  );
+  const [selectedYear, setSelectedYear] = useState<string>(
+    () => new Date().getFullYear().toString(),
+  );
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("YTD");
   const [viewMode, setViewMode] = useState<ViewMode>("Total");
   const [notification, setNotification] = useState<NotificationState>({
@@ -328,8 +332,9 @@ export default function FinancialsPage() {
     let endDate: string;
 
     if (timePeriod === "Custom") {
-      startDate = customStartDate || "2025-01-01";
-      endDate = customEndDate || "2025-06-30";
+      const year = new Date().getFullYear();
+      startDate = customStartDate || `${year}-01-01`;
+      endDate = customEndDate || `${year}-12-31`;
     } else if (timePeriod === "YTD") {
       const monthIndex = monthsList.indexOf(selectedMonth);
       const year = Number.parseInt(selectedYear);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,8 +144,12 @@ const classifyCashFlowTransaction = (accountType) => {
 
 export default function FinancialOverviewPage() {
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedMonth, setSelectedMonth] = useState("June");
-  const [selectedYear, setSelectedYear] = useState("2024");
+  const [selectedMonth, setSelectedMonth] = useState(
+    () => new Date().toLocaleString("en-US", { month: "long" }),
+  );
+  const [selectedYear, setSelectedYear] = useState(
+    () => new Date().getFullYear().toString(),
+  );
   type TimePeriod = "Monthly" | "Quarterly" | "YTD" | "Trailing 12" | "Custom";
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("YTD");
   const [timePeriodDropdownOpen, setTimePeriodDropdownOpen] = useState(false);


### PR DESCRIPTION
## Summary
- use current month and year as defaults for dashboard filters
- adjust custom date ranges to derive from the current year

## Testing
- `pnpm lint` *(fails: Do not pass children as props, many unexpected any)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b06ffc288333823bfcfdfb562ed3