### PR TITLE
Center financial page headers

### DIFF
--- a/src/app/accounts-payable/page.tsx
+++ b/src/app/accounts-payable/page.tsx
@@ -404,16 +404,16 @@ export default function AccountsPayablePage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Accounts Payable</h1>
-              <p className="text-sm text-gray-600 mt-1">Real-time A/P aging from imported vendor bills</p>
-              <p className="text-xs text-blue-600 mt-1">📊 Connected to ap_aging table • Synced hourly</p>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex-1 text-center">
+              <h1 className="text-2xl font-bold text-gray-900 text-center">Accounts Payable</h1>
+              <p className="text-sm text-gray-600 mt-1 text-center">Real-time A/P aging from imported vendor bills</p>
+              <p className="text-xs text-blue-600 mt-1 text-center">📊 Connected to ap_aging table • Synced hourly</p>
             </div>
             <button
               onClick={fetchAPData}
               disabled={isLoading}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm disabled:opacity-50"
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm disabled:opacity-50 mt-4 sm:mt-0"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
               Refresh
@@ -495,8 +495,8 @@ export default function AccountsPayablePage() {
           {/* Aging Analysis */}
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <div className="p-6 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Aging Analysis (A/P)</h3>
-              <div className="text-sm text-gray-600 mt-1">Current aging breakdown from latest imported data</div>
+              <h3 className="text-lg font-semibold text-gray-900 text-center">Aging Analysis (A/P)</h3>
+              <div className="text-sm text-gray-600 mt-1 text-center">Current aging breakdown from latest imported data</div>
             </div>
 
             <div className="p-6">
@@ -582,8 +582,8 @@ export default function AccountsPayablePage() {
           {/* A/P Table */}
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <div className="p-6 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Outstanding Payables</h3>
-              <div className="text-sm text-gray-600 mt-1">
+              <h3 className="text-lg font-semibold text-gray-900 text-center">Outstanding Payables</h3>
+              <div className="text-sm text-gray-600 mt-1 text-center">
                 Showing {filteredData.length} of {apGroupedData.length} vendor groups • Click any amount to drill down
               </div>
             </div>
@@ -791,8 +791,8 @@ export default function AccountsPayablePage() {
           <div className="bg-white rounded-lg max-w-5xl w-full max-h-[80vh] flex flex-col">
             <div className="p-6 border-b border-gray-200 flex-shrink-0">
               <div className="flex justify-between items-center">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
+                <div className="flex-1 text-center">
+                  <h3 className="text-lg font-semibold text-gray-900 text-center">
                     {selectedAgingFilter && selectedAgingFilter !== "all"
                       ? `${
                           selectedAgingFilter === "current"
@@ -805,7 +805,7 @@ export default function AccountsPayablePage() {
                         } Bills — ${selectedVendorData.vendor}`
                       : `All Outstanding Bills — ${selectedVendorData.vendor}`}
                   </h3>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 text-center">
                     {selectedAgingFilter && selectedAgingFilter !== "all"
                       ? `Showing ${filteredBills.length} bills • Total: ${formatCurrency(
                           filteredBills.reduce((s, b) => s + b.open_balance, 0)

--- a/src/app/accounts-receivable/page.tsx
+++ b/src/app/accounts-receivable/page.tsx
@@ -568,20 +568,20 @@ export default function AccountsReceivablePage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Accounts Receivable</h1>
-              <p className="text-sm text-gray-600 mt-1">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex-1 text-center">
+              <h1 className="text-2xl font-bold text-gray-900 text-center">Accounts Receivable</h1>
+              <p className="text-sm text-gray-600 mt-1 text-center">
                 Real-time A/R aging from imported aging detail reports
               </p>
-              <p className="text-xs text-blue-600 mt-1">
+              <p className="text-xs text-blue-600 mt-1 text-center">
                 📊 Connected to ar_aging_detail table • Synced hourly
               </p>
             </div>
             <button
               onClick={fetchARData}
               disabled={isLoading}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm disabled:opacity-50"
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm disabled:opacity-50 mt-4 sm:mt-0"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
               Refresh
@@ -675,8 +675,8 @@ export default function AccountsReceivablePage() {
           {/* Aging Analysis */}
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <div className="p-6 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Aging Analysis</h3>
-              <div className="text-sm text-gray-600 mt-1">Current aging breakdown from latest imported data</div>
+              <h3 className="text-lg font-semibold text-gray-900 text-center">Aging Analysis</h3>
+              <div className="text-sm text-gray-600 mt-1 text-center">Current aging breakdown from latest imported data</div>
             </div>
 
             <div className="p-6">
@@ -774,8 +774,8 @@ export default function AccountsReceivablePage() {
           {/* A/R Table */}
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <div className="p-6 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Outstanding Receivables</h3>
-              <div className="text-sm text-gray-600 mt-1">
+              <h3 className="text-lg font-semibold text-gray-900 text-center">Outstanding Receivables</h3>
+              <div className="text-sm text-gray-600 mt-1 text-center">
                 Showing {filteredData.length} of {arGroupedData.length} customer groups • Click any amount to drill down
               </div>
             </div>
@@ -1051,17 +1051,17 @@ export default function AccountsReceivablePage() {
           <div className="bg-white rounded-lg max-w-5xl w-full max-h-[80vh] flex flex-col">
             <div className="p-6 border-b border-gray-200 flex-shrink-0">
               <div className="flex justify-between items-center">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    {selectedAgingFilter && selectedAgingFilter !== 'all' 
-                      ? `${selectedAgingFilter === 'current' ? 'Current (0-30)' : 
+                <div className="flex-1 text-center">
+                  <h3 className="text-lg font-semibold text-gray-900 text-center">
+                    {selectedAgingFilter && selectedAgingFilter !== 'all'
+                      ? `${selectedAgingFilter === 'current' ? 'Current (0-30)' :
                           selectedAgingFilter === '31-60' ? '31-60 Days' :
                           selectedAgingFilter === '61-90' ? '61-90 Days' :
                           '90+ Days'} Invoices - ${selectedCustomerData.customer}`
                       : `All Outstanding Invoices - ${selectedCustomerData.customer}`
                     }
                   </h3>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 text-center">
                     {selectedAgingFilter && selectedAgingFilter !== 'all'
                       ? `Showing ${filteredInvoices.length} invoices in this aging category • Total: ${formatCurrency(filteredInvoices.reduce((sum, inv) => sum + inv.open_balance, 0))}`
                       : `Outstanding balance: ${formatCurrency(selectedCustomerData.balance)} • ${selectedCustomerData.invoiceCount} invoices`
@@ -1146,7 +1146,7 @@ export default function AccountsReceivablePage() {
           <div className="bg-white rounded-lg max-w-4xl w-full max-h-[80vh] flex flex-col">
             <div className="p-6 border-b border-gray-200 flex-shrink-0">
               <div className="flex justify-between items-center">
-                <h3 className="text-lg font-semibold text-gray-900">
+                <h3 className="flex-1 text-lg font-semibold text-gray-900 text-center">
                   Payments - {selectedPaymentCustomer}
                 </h3>
                 <button
@@ -1195,11 +1195,11 @@ export default function AccountsReceivablePage() {
           <div className="bg-white rounded-lg max-w-6xl w-full max-h-[80vh] flex flex-col">
             <div className="p-6 border-b border-gray-200 flex-shrink-0">
               <div className="flex justify-between items-center">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
+                <div className="flex-1 text-center">
+                  <h3 className="text-lg font-semibold text-gray-900 text-center">
                     Journal Entry Details
                   </h3>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 text-center">
                     Invoice #{selectedJournalEntry[0]?.number} • Entry #{selectedJournalEntry[0]?.entry_number} • Date: {formatDateSafe(selectedJournalEntry[0]?.date)} • {selectedJournalEntry.length} lines
                   </p>
                 </div>

--- a/src/app/balance-sheet/page.tsx
+++ b/src/app/balance-sheet/page.tsx
@@ -889,8 +889,8 @@ export default function BalanceSheetPage() {
     return (
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
         <div className={`p-4 sm:p-6 border-b border-gray-200 ${colors.header}`}>
-          <div className="flex justify-between items-center">
-            <h3 className="text-lg font-semibold flex items-center">
+          <div className="flex items-center justify-between">
+            <h3 className="flex-1 text-lg font-semibold flex items-center justify-center text-center">
               <span className={`w-4 h-4 ${colors.dot} rounded-full mr-3`}></span>
               {section.title}
             </h3>
@@ -1032,9 +1032,9 @@ export default function BalanceSheetPage() {
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div>
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Balance Sheet</h1>
-              <p className="text-xs sm:text-sm text-gray-600 mt-1">
+            <div className="flex-1 text-center">
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 text-center">Balance Sheet</h1>
+              <p className="text-xs sm:text-sm text-gray-600 mt-1 text-center">
                 As of{" "}
                 {asOfDate
                   ? formatDate(asOfDate)
@@ -1044,7 +1044,7 @@ export default function BalanceSheetPage() {
                       ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
                       : `${timePeriod} Period`}
               </p>
-              <p className="text-xs text-blue-600 mt-1">
+              <p className="text-xs text-blue-600 mt-1 text-center">
                 💰 Enhanced with account type subtotals and corrected balance calculations
               </p>
             </div>
@@ -1052,7 +1052,7 @@ export default function BalanceSheetPage() {
             <button
               onClick={loadData}
               disabled={isLoading}
-              className="flex items-center gap-2 px-3 sm:px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+              className="flex items-center gap-2 px-3 sm:px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50 mt-4 sm:mt-0"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
               <span className="hidden sm:inline">Refresh</span>
@@ -1246,9 +1246,9 @@ export default function BalanceSheetPage() {
             {/* Fixed Header */}
             <div className="flex-shrink-0 p-4 sm:p-6 border-b border-gray-200">
               <div className="flex justify-between items-center">
-                <div>
-                  <h3 className="text-base sm:text-lg font-semibold text-gray-900">{modalTitle}</h3>
-                  <p className="text-xs sm:text-sm text-gray-600">{transactionDetails.length} transactions</p>
+                <div className="text-center flex-1">
+                  <h3 className="text-base sm:text-lg font-semibold text-gray-900 text-center">{modalTitle}</h3>
+                  <p className="text-xs sm:text-sm text-gray-600 text-center">{transactionDetails.length} transactions</p>
                 </div>
                 <button onClick={() => setShowTransactionModal(false)} className="text-gray-400 hover:text-gray-600">
                   <X className="w-5 h-5 sm:w-6 sm:h-6" />
@@ -1421,7 +1421,7 @@ export default function BalanceSheetPage() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg max-w-3xl w-full max-h-[80vh] flex flex-col">
             <div className="p-4 border-b border-gray-200 flex justify-between items-center flex-shrink-0">
-              <h3 className="text-lg font-semibold text-gray-900">{journalTitle}</h3>
+              <h3 className="flex-1 text-lg font-semibold text-gray-900 text-center">{journalTitle}</h3>
               <button
                 onClick={() => setShowJournalModal(false)}
                 className="text-gray-400 hover:text-gray-600"

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -1351,17 +1351,17 @@ export default function FinancialsPage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-6">
-            <div className="flex items-center space-x-4">
+          <div className="flex items-center py-6">
+            <div className="flex-1 flex items-center justify-center space-x-4">
               <TrendingUp
                 className="w-8 h-8"
                 style={{ color: BRAND_COLORS.primary }}
               />
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">
+              <div className="text-center">
+                <h1 className="text-2xl font-bold text-gray-900 text-center">
                   Profit & Loss Statement
                 </h1>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 text-center">
                   {timePeriod === "Custom"
                     ? `${formatDateDisplay(currentStartDate)} - ${formatDateDisplay(currentEndDate)}`
                     : timePeriod === "Monthly"
@@ -1374,7 +1374,7 @@ export default function FinancialsPage() {
                             ? `${formatDateDisplay(currentStartDate)} - ${formatDateDisplay(currentEndDate)}`
                             : `${timePeriod} Period`}
                 </p>
-                <p className="text-xs text-blue-600 mt-1">
+                <p className="text-xs text-blue-600 mt-1 text-center">
                   💰 Using timezone-independent date handling for precise P&L
                   classification
                 </p>
@@ -1663,10 +1663,10 @@ export default function FinancialsPage() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {dataError ? (
           <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-            <h3 className="text-lg font-medium text-red-800 mb-2">
+            <h3 className="text-lg font-medium text-red-800 mb-2 text-center">
               Error Loading Data
             </h3>
-            <p className="text-red-700">{dataError}</p>
+            <p className="text-red-700 text-center">{dataError}</p>
             <button
               onClick={fetchPLData}
               className="mt-4 inline-flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
@@ -1780,11 +1780,11 @@ export default function FinancialsPage() {
 
             {/* P&L Statement Table */}
             <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
-              <div className="px-6 py-4 border-b border-gray-200">
-                <h2 className="text-lg font-semibold text-gray-900">
+              <div className="px-6 py-4 border-b border-gray-200 text-center">
+                <h2 className="text-lg font-semibold text-gray-900 text-center">
                   Profit & Loss Statement - {viewMode} View
                 </h2>
-                <p className="text-sm text-gray-600 mt-1">
+                <p className="text-sm text-gray-600 mt-1 text-center">
                   {plAccounts.length} accounts • Timezone-independent date
                   handling • Using account_type for P&L classification
                   {viewMode === "Detail" && " • Monthly breakdown"}
@@ -2927,7 +2927,7 @@ export default function FinancialsPage() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg max-w-3xl w-full max-h-[80vh] flex flex-col">
             <div className="p-4 border-b border-gray-200 flex justify-between items-center flex-shrink-0">
-              <h3 className="text-lg font-semibold text-gray-900">{journalEntryTitle}</h3>
+              <h3 className="flex-1 text-lg font-semibold text-gray-900 text-center">{journalEntryTitle}</h3>
               <button
                 onClick={() => setShowJournalEntryModal(false)}
                 className="text-gray-400 hover:text-gray-600"

--- a/src/app/payroll/page.tsx
+++ b/src/app/payroll/page.tsx
@@ -434,16 +434,16 @@ export default function PayrollPage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center">
+          <div className="flex items-center justify-center">
             <IAMCFOLogo className="w-8 h-8 mr-4" />
             <div>
-              <div className="flex items-center space-x-3">
-                <h1 className="text-2xl font-bold text-gray-900">I AM CFO</h1>
+              <div className="flex items-center justify-center space-x-3">
+                <h1 className="text-2xl font-bold text-gray-900 text-center">I AM CFO</h1>
                 <span className="text-sm px-3 py-1 rounded-full text-white" style={{ backgroundColor: BRAND_COLORS.primary }}>
                   Payroll Management
                 </span>
               </div>
-              <p className="text-sm text-gray-600 mt-1">Live payments from Supabase • Department insights • Simple exports</p>
+              <p className="text-sm text-gray-600 mt-1 text-center">Live payments from Supabase • Department insights • Simple exports</p>
             </div>
           </div>
         </div>
@@ -453,10 +453,10 @@ export default function PayrollPage() {
         <div className="space-y-8">
           {/* Controls */}
           <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4">
-            <h2 className="text-3xl font-bold" style={{ color: BRAND_COLORS.primary }}>
+            <h2 className="flex-1 text-3xl font-bold text-center" style={{ color: BRAND_COLORS.primary }}>
               Overview
             </h2>
-            <div className="flex flex-wrap gap-4 items-center">
+            <div className="flex flex-wrap gap-4 items-center justify-center lg:justify-end">
               {/* Search */}
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
@@ -679,9 +679,9 @@ export default function PayrollPage() {
             {/* Trend */}
             <div className="bg-white rounded-xl shadow-sm overflow-hidden">
               <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-                <div>
-                  <h3 className="text-xl font-semibold text-gray-900">Year-to-Date Payments Trend</h3>
-                  <p className="text-sm text-gray-600 mt-1">Gross/Net show same value (no tax split in table)</p>
+                <div className="flex-1 text-center">
+                  <h3 className="text-xl font-semibold text-gray-900 text-center">Year-to-Date Payments Trend</h3>
+                  <p className="text-sm text-gray-600 mt-1 text-center">Gross/Net show same value (no tax split in table)</p>
                 </div>
                 <div className="flex items-center gap-2">
                   <button
@@ -724,9 +724,9 @@ export default function PayrollPage() {
             {/* Department Totals */}
             <div className="bg-white rounded-xl shadow-sm overflow-hidden">
               <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-                <div>
-                  <h3 className="text-xl font-semibold text-gray-900">Totals by Department</h3>
-                  <p className="text-sm text-gray-600 mt-1">Distribution of payment totals</p>
+                <div className="flex-1 text-center">
+                  <h3 className="text-xl font-semibold text-gray-900 text-center">Totals by Department</h3>
+                  <p className="text-sm text-gray-600 mt-1 text-center">Distribution of payment totals</p>
                 </div>
                 <div className="flex items-center gap-2">
                   <button
@@ -783,9 +783,9 @@ export default function PayrollPage() {
           {/* Summary */}
           <div className="bg-white rounded-xl shadow-sm overflow-hidden mt-8">
             <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-              <div className="flex items-center">
+              <div className="flex items-center justify-center flex-1">
                 <IAMCFOLogo className="w-6 h-6 mr-2" />
-                <h3 className="text-xl font-semibold text-gray-900">
+                <h3 className="text-xl font-semibold text-gray-900 text-center">
                   {summaryView === "department" ? "Department Summary" : "Date Summary"}
                 </h3>
               </div>


### PR DESCRIPTION
## Summary
- Centered Balance Sheet header and section titles
- Aligned Financials, Accounts Receivable/Payable, and Payroll page headers and subheaders to the center

## Testing
- `pnpm lint` *(fails: ELIFECYCLE exit code 1)*
- `pnpm type-check` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b45c12e3a88333b29d430afd13980a